### PR TITLE
feat: add statistic component

### DIFF
--- a/__tests__/Statistic.test.tsx
+++ b/__tests__/Statistic.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { Statistic } from "@components/Statistic";
+
+test("Currency statistic", () => {
+	const props = {
+		label: "TVL",
+		value: 14800000,
+		currency: "USDC",
+		isPercentage: false,
+	};
+
+	const component = renderer.create(<Statistic {...props} />);
+
+	const tree = component.toJSON();
+	expect(tree).toMatchSnapshot();
+});
+
+test("Percentage statistic", () => {
+	const props = {
+		label: "Estimated APY",
+		value: 0.138,
+		isPercentage: true,
+	};
+
+	const component = renderer.create(<Statistic {...props} />);
+
+	const tree = component.toJSON();
+	expect(tree).toMatchSnapshot();
+});

--- a/__tests__/__snapshots__/Statistic.test.tsx.snap
+++ b/__tests__/__snapshots__/Statistic.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Currency statistic 1`] = `
+<div
+  className="bg-credix-primary border border-solid border-darker rounded-[1px] font-sans h-36 min-w-[16rem] w-min ml-[21.5px] pr-5 flex items-center"
+>
+  <div
+    className="bg-credix-primary ml-[-21.5px]"
+  >
+    <div>
+      TVL
+    </div>
+    <div
+      className="text-6xl font-bold"
+    >
+      14.8M
+      <span
+        className="text-sm font-normal"
+      >
+        USDC
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Percentage statistic 1`] = `
+<div
+  className="bg-credix-primary border border-solid border-darker rounded-[1px] font-sans h-36 min-w-[16rem] w-min ml-[21.5px] pr-5 flex items-center"
+>
+  <div
+    className="bg-credix-primary ml-[-21.5px]"
+  >
+    <div>
+      Estimated APY
+    </div>
+    <div
+      className="text-6xl font-bold"
+    >
+      13.8%
+      <span
+        className="text-sm font-normal"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Statistic.tsx
+++ b/src/components/Statistic.tsx
@@ -1,0 +1,35 @@
+import React, { useMemo } from "react";
+
+interface StatisticProps {
+	label: string;
+	value: number;
+	currency?: string;
+	isPercentage?: boolean;
+}
+
+export const Statistic = ({ label, value, currency, isPercentage = false }: StatisticProps) => {
+	const formatter = useMemo(
+		() =>
+			Intl.NumberFormat("en", {
+				style: isPercentage ? "percent" : undefined,
+				notation: !isPercentage ? "compact" : undefined,
+				minimumFractionDigits: 0,
+				maximumFractionDigits: 1,
+			}),
+		[isPercentage]
+	);
+
+	const formattedValue = useMemo(() => formatter.format(value), [formatter, value]);
+
+	return (
+		<div className="bg-credix-primary border border-solid border-darker rounded-[1px] font-sans h-36 min-w-[16rem] w-min ml-[21.5px] pr-5 flex items-center">
+			<div className="bg-credix-primary ml-[-21.5px]">
+				<div>{label}</div>
+				<div className="text-6xl font-bold">
+					{formattedValue}
+					<span className="text-sm font-normal">{currency}</span>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/stories/Statistic.stories.tsx
+++ b/src/stories/Statistic.stories.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { Statistic } from "@components/Statistic";
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+	title: "Statistic",
+	component: Statistic,
+} as ComponentMeta<typeof Statistic>;
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Template: ComponentStory<typeof Statistic> = (args) => <Statistic {...args} />;
+
+export const Currency = Template.bind({});
+Currency.args = {
+	label: "TVL",
+	value: 14800000,
+	currency: "USDC",
+	isPercentage: false,
+};
+
+export const Percentage = Template.bind({});
+Percentage.args = {
+	label: "Estimated APY",
+	value: 0.138,
+	isPercentage: true,
+};


### PR DESCRIPTION
This PR will add:
 
- Statistics component that uses the `Intl.NumberFormat` to either format percentages or numbers. 
- Storybook stories for number and percentage statistics.
- Snapshot tests for number and percentage statistics.
 
I couldn't find a good name for this component. "Statistic" doesn't feel right for me, but the ticket speaks of a "MainDataKeyStatistic" which isn't great as well. So any suggestions are welcome otherwise it'll be "Statistic".