### PR TITLE
feat: move "invest" button so it in line with the deals table tabs

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -3,6 +3,7 @@ import { Tabs as AntdTabs } from "antd";
 import { TabsProps as AntTabsProps } from "antd/lib/tabs";
 
 interface TabsProps {
+	tabBarExtraContent: AntTabsProps["tabBarExtraContent"];
 	children?: AntTabsProps["children"];
 }
 

--- a/src/pages/[marketplace]/deals.tsx
+++ b/src/pages/[marketplace]/deals.tsx
@@ -90,19 +90,18 @@ const Deals: NextPageWithLayout = () => {
 		[locales]
 	);
 
+	const investButton = (
+		<Link href={`/${marketplace}/invest`}>
+			<a>
+				<Button size="large" icon={<Icon name="plus-square" className="w-5 h-5" />}>
+					<span className="text-lg">Invest</span>
+				</Button>
+			</a>
+		</Link>
+	);
 	return (
 		<div className="space-y-14 py-5 px-4 md:pt-12 md:px-28">
-			<div className="flex justify-between">
-				<div></div>
-				<Link href={`/${marketplace}/invest`}>
-					<a>
-						<Button size="large" icon={<Icon name="plus-square" className="w-5 h-5" />}>
-							<span className="text-lg">Invest</span>
-						</Button>
-					</a>
-				</Link>
-			</div>
-			<Tabs>
+			<Tabs tabBarExtraContent={investButton}>
 				<TabPane tab="Active Deals" key="activeDealsTab">
 					<Table
 						loading={isLoadingDeals}


### PR DESCRIPTION
This PR will:

- Move the "invest" button so that it is inline with the deals table tabs

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] CI succeeded and formatting has been applied.
- [x] Unit tests have been created if a new feature was added.