### PR TITLE
fix: remove redundant PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,4 @@
 ## Checklist
 
 - [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
-- [ ] CI succeeded and formatting has been applied.
 - [ ] Unit tests have been created if a new feature was added.


### PR DESCRIPTION
This PR removes redundant check in the PR template.

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] Unit tests have been created if a new feature was added.
