### PR TITLE
Wallet dropdown button width

### DIFF
--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -21,7 +21,7 @@ export const WalletButton = ({ className = "" }: WalletButtonProps) => {
 			return "Connecting";
 		}
 
-		return base58.slice(0, 4) + ".." + base58.slice(-4);
+		return base58.slice(0, 5) + ".." + base58.slice(-5);
 	}, [wallet, base58]);
 
 	const copyAddress = useCallback(async () => {
@@ -51,12 +51,12 @@ export const WalletButton = ({ className = "" }: WalletButtonProps) => {
 				type="default"
 				onClick={() => setDropdownVisible(!dropdownVisible)}
 				icon={<WalletIcon wallet={wallet} className="w-6" />}
-				className={className}
+				className={`${className} w-56`}
 			>
 				{address}
 			</Button>
 			<div
-				className={`absolute z-10 whitespace-nowrap right-0 grid grid-cols-1 bg-credix-primary rounded-sm w-56 border border-solid border-neutral-100 divide-y divide-neutral-100 ${
+				className={`absolute top-[60px] z-10 whitespace-nowrap right-0 grid grid-cols-1 bg-credix-primary rounded-sm w-56 border border-solid border-neutral-100 divide-y divide-neutral-100 ${
 					dropdownVisible ? "block" : "hidden"
 				}`}
 			>

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -49,6 +49,7 @@ export const WalletButton = ({ className = "" }: WalletButtonProps) => {
 		<div className="relative" onBlur={() => setTimeout(() => setDropdownVisible(false), 100)}>
 			<Button
 				type="default"
+				size="large"
 				onClick={() => setDropdownVisible(!dropdownVisible)}
 				icon={<WalletIcon wallet={wallet} className="w-6" />}
 				className={`${className} w-56`}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -33,7 +33,7 @@ body {
 }
 
 .identity-button > button {
-	@apply bg-credix-primary text-neutral-100 h-[42px] flex justify-center items-center;
+	@apply bg-credix-primary text-neutral-100 h-[50px] flex justify-center items-center;
 }
 
 .identity-button > button > svg {


### PR DESCRIPTION
This PR will:

- Make the wallet button dropdown as wide as the wallet button
- Add a small gap between the button and the dropdown
- make the civic button and connected wallet button as tall as the wallet button

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] Unit tests have been created if a new feature was added.
