### PR TITLE
feat: add typeform buttons on index page when user has no credix pass

### DIFF
--- a/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/__tests__/__snapshots__/Button.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Outline button 1`] = `
 				hover:text-neutral-60 hover:border-neutral-60
 				active:text-neutral-40 active:border-neutral-60
 				disabled:border-action-disable disabled:text-disabled
-			 text-base font-medium h-[42px] "
+			 text-base font-medium h-[42px]"
   onClick={[Function]}
   type="button"
 >
@@ -24,7 +24,7 @@ exports[`Outline button disabled 1`] = `
 				hover:text-neutral-60 hover:border-neutral-60
 				active:text-neutral-40 active:border-neutral-60
 				disabled:border-action-disable disabled:text-disabled
-			 text-base font-medium h-[42px] "
+			 text-base font-medium h-[42px]"
   disabled={true}
   onClick={[Function]}
   type="button"
@@ -42,7 +42,7 @@ exports[`Outline button with icon 1`] = `
 				hover:text-neutral-60 hover:border-neutral-60
 				active:text-neutral-40 active:border-neutral-60
 				disabled:border-action-disable disabled:text-disabled
-			 text-base font-medium h-[42px] "
+			 text-base font-medium h-[42px]"
   onClick={[Function]}
   type="button"
 >
@@ -68,7 +68,7 @@ exports[`Primary button 1`] = `
 				hover:bg-neutral-60 hover:border-neutral-60
 				active:bg-neutral-40 active:border-neutral-40 active:text-neutral-100
 				disabled:bg-action-disable disabled:border-transparent disabled:text-disabled
-			 text-base font-medium h-[42px] "
+			 text-base font-medium h-[42px]"
   onClick={[Function]}
   type="button"
 >
@@ -85,7 +85,7 @@ exports[`Primary button disabled 1`] = `
 				hover:bg-neutral-60 hover:border-neutral-60
 				active:bg-neutral-40 active:border-neutral-40 active:text-neutral-100
 				disabled:bg-action-disable disabled:border-transparent disabled:text-disabled
-			 text-base font-medium h-[42px] "
+			 text-base font-medium h-[42px]"
   disabled={true}
   onClick={[Function]}
   type="button"
@@ -103,7 +103,7 @@ exports[`Primary button with icon 1`] = `
 				hover:bg-neutral-60 hover:border-neutral-60
 				active:bg-neutral-40 active:border-neutral-40 active:text-neutral-100
 				disabled:bg-action-disable disabled:border-transparent disabled:text-disabled
-			 text-base font-medium h-[42px] "
+			 text-base font-medium h-[42px]"
   onClick={[Function]}
   type="button"
 >

--- a/__tests__/__snapshots__/WalletButon.test.tsx.snap
+++ b/__tests__/__snapshots__/WalletButon.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Wallet button 1`] = `
 				hover:bg-neutral-60 hover:border-neutral-60
 				active:bg-neutral-40 active:border-neutral-40 active:text-neutral-100
 				disabled:bg-action-disable disabled:border-transparent disabled:text-disabled
-			 text-lg font-semibold h-[50px] "
+			 text-lg font-semibold h-[50px]"
   onClick={[Function]}
   type="button"
 >

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"@solana/wallet-adapter-wallets": "^0.14.3",
 		"@solana/web3.js": "^1.36.0",
 		"@tailwindcss/forms": "^0.5.0",
+		"@typeform/embed-react": "^1.13.0",
 		"antd": "^4.19.3",
 		"autoprefixer": "^10.4.4",
 		"big.js": "^6.1.1",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -36,7 +36,7 @@ interface ButtonProps {
 	htmlType?: AntButtonProps["htmlType"];
 }
 
-const buttonTypeStyles = {
+export const buttonTypeStyles = {
 	primary: `
 				bg-action-primary border-action-primary text-credix-primary
 				hover:bg-neutral-60 hover:border-neutral-60
@@ -51,26 +51,28 @@ const buttonTypeStyles = {
 			`,
 };
 
-const buttonSizeStyles = {
+export const buttonSizeStyles = {
 	small: "text-sm font-semibold h-10",
 	middle: "text-base font-medium h-[42px]",
 	large: "text-lg font-semibold h-[50px]",
 };
 
+export const defaultButtonStyles =
+	"rounded-[1px] border text-shadow-none shadow-none flex items-center justify-center gap-2 px-[25px]";
+
 export const Button = ({
 	children,
-	className = "",
+	className,
 	size = "middle",
 	type = "primary",
 	...props
 }: ButtonProps) => {
+	className = [defaultButtonStyles, buttonTypeStyles[type], buttonSizeStyles[size], className]
+		.filter(Boolean)
+		.join(" ");
+
 	return (
-		<AntdButton
-			className={`rounded-[1px] border text-shadow-none shadow-none flex items-center justify-center gap-2 px-[25px] ${buttonTypeStyles[type]} ${buttonSizeStyles[size]} ${className}`}
-			size={size}
-			type={type}
-			{...props}
-		>
+		<AntdButton className={className} size={size} type={type} {...props}>
 			{children}
 		</AntdButton>
 	);

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,6 +3,7 @@ import { Route } from "types/route.types";
 
 export const defaultMarketplace = "credix-marketplace";
 export const multisigUrl = "https://multisig.credix.finance/#/";
+export const typeformID = "E98Qjiw9";
 
 export const investWithdrawRoute: Route = {
 	icon: "line-chart" as IconName,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4569,6 +4569,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typeform/embed-react@npm:^1.13.0":
+  version: 1.13.0
+  resolution: "@typeform/embed-react@npm:1.13.0"
+  dependencies:
+    "@typeform/embed": 1.34.1
+    fast-deep-equal: ^3.1.3
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 5c5facd1952d7b8cfd7f7943a2f456893ea8c19aad950ec2443b9adfdec813c0049ae96e237af0fb2fa472bf4fda5befe47428a188557dde5da230ceb2388fa8
+  languageName: node
+  linkType: hard
+
+"@typeform/embed@npm:1.34.1":
+  version: 1.34.1
+  resolution: "@typeform/embed@npm:1.34.1"
+  checksum: 13a56c4cc489a0689c5bbfa5705857ff93fca844e329c400a4e071003229b91085d2bc3f4ca5f30ec796de307b87a60f4fac6192d3917e19c6acce2155ad9f1f
+  languageName: node
+  linkType: hard
+
 "@types/aria-query@npm:^4.2.0":
   version: 4.2.2
   resolution: "@types/aria-query@npm:4.2.2"
@@ -7640,6 +7659,7 @@ __metadata:
     "@tailwindcss/forms": ^0.5.0
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.4
+    "@typeform/embed-react": ^1.13.0
     "@types/big.js": ^6.1.3
     "@types/node": ^17.0.21
     "@types/react": ^17.0.41


### PR DESCRIPTION
This PR will:

- show Typeform buttons instead of normal buttons on the index page when the user has no credix pass

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] Unit tests have been created if a new feature was added.
