### PR TITLE
feat: move index page to root of the project

### DIFF
--- a/__tests__/__snapshots__/MainMenu.test.tsx.snap
+++ b/__tests__/__snapshots__/MainMenu.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Main menu 1`] = `
 >
   <div>
     <a
-      href="/undefined"
+      href="/"
       onClick={[Function]}
       onMouseEnter={[Function]}
     >

--- a/next.config.js
+++ b/next.config.js
@@ -17,13 +17,4 @@ module.exports = withLess({
 	reactStrictMode: false,
 	basePath: process.env.NEXT_PUBLIC_BASE_PATH,
 	assetPrefix: process.env.NEXT_PUBLIC_BASE_PATH,
-	async redirects() {
-		return [
-			{
-				source: "/",
-				destination: "/credix-marketplace",
-				permanent: true,
-			},
-		];
-	},
 });

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -14,11 +14,13 @@ interface MainMenuProps {
 export const MainMenu = ({ showLogo = true }: MainMenuProps) => {
 	const router = useRouter();
 
+	const path = (router?.query?.marketplace as string) || "/";
+
 	return (
 		<div className="w-full bg-credix-primary flex justify-between items-center p-5">
 			<div>
 				{showLogo && (
-					<Link href={`/${router?.query?.marketplace}`}>
+					<Link href={path}>
 						<a>
 							<CredixLogo mode="dark" />
 						</a>

--- a/src/components/Marketplace.tsx
+++ b/src/components/Marketplace.tsx
@@ -1,0 +1,77 @@
+import { FunctionComponent, useEffect } from "react";
+import { Button } from "@components/Button";
+import { Card } from "@components/Card";
+import { MarketStats } from "@components/MarketStats";
+import { useCredixClient } from "@credix/credix-client";
+import Link from "next/link";
+import { dealsRoute, investWithdrawRoute } from "@consts";
+import { useStore } from "@state/useStore";
+
+interface MarketplaceProps {
+	marketplace: string;
+}
+
+const Marketplace: FunctionComponent<MarketplaceProps> = ({ marketplace }) => {
+	const client = useCredixClient();
+	const fetchMarket = useStore((state) => state.fetchMarket);
+	const market = useStore((state) => state.market);
+
+	useEffect(() => {
+		fetchMarket(client, marketplace);
+	}, [client, fetchMarket, marketplace]);
+
+	const parties = [
+		{
+			name: "liquidity providers",
+			action: "invest",
+			buttonAction: "Invest",
+			buttonLink: investWithdrawRoute.path,
+			description:
+				"Stable return, flexibility to withdraw at any moment and invest in senior tranche = liquidity pool.",
+		},
+		{
+			name: "Borrowers",
+			action: "borrow",
+			buttonAction: "deals",
+			buttonLink: dealsRoute.path,
+			description:
+				"Stable return, flexibility to withdraw at any moment and invest in senior tranche = liquidity pool.",
+		},
+	];
+
+	return (
+		<main
+			id="index"
+			className="grid grid-cols-1 grid-auto-rows-min gap-y-8 md:grid-cols-12 md:gap-y-12 md:gap-x-14 justify-items-center p-4 pt-8 md:p-8 lg:max-w-6xl lg:justify-self-center"
+		>
+			<div className="text-center md:col-span-12 md:max-w-3xl grid justify-items-center">
+				<h1 className="text-5xl md:text-6xl lg:text-7xl font-semibold font-sans">
+					Welcome to Credix
+				</h1>
+				<div className="font-normal text-base md:max-w-lg">
+					The new decentralized credit marketplace connecting investors with FinTechs in emerging
+					markets
+				</div>
+			</div>
+			<div className="md:col-span-12 w-full">
+				<MarketStats market={market} />
+			</div>
+			<div className="ml-6 md:col-span-12 md:flex md:justify-between md:space-x-20 space-y-8 md:space-y-0">
+				{parties.map(({ name, action, buttonAction, buttonLink, description }) => (
+					<Card key={name} topTitle={name} title={action} offset="large">
+						<div className="mb-14 text-base">{description}</div>
+						<Link href={`/${marketplace}${buttonLink}`}>
+							<a>
+								<Button block={true} className="capitalize">
+									{buttonAction}
+								</Button>
+							</a>
+						</Link>
+					</Card>
+				))}
+			</div>
+		</main>
+	);
+};
+
+export default Marketplace;

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,6 +1,7 @@
 import { IconName } from "@components/Icon";
 import { Route } from "types/route.types";
 
+export const defaultMarketplace = "credix-marketplace";
 export const multisigUrl = "https://multisig.credix.finance/#/";
 
 export const investWithdrawRoute: Route = {

--- a/src/pages/[marketplace]/index.tsx
+++ b/src/pages/[marketplace]/index.tsx
@@ -1,78 +1,14 @@
-import { useEffect, ReactElement } from "react";
-import { Button } from "@components/Button";
-import { Card } from "@components/Card";
-import { MarketStats } from "@components/MarketStats";
-import { useCredixClient } from "@credix/credix-client";
+import { ReactElement } from "react";
 import { useRouter } from "next/router";
 import Layout from "@components/Layout";
 import { NextPageWithLayout } from "pages/_app";
-import Link from "next/link";
-import { dealsRoute, investWithdrawRoute } from "@consts";
-import { useStore } from "@state/useStore";
+import Marketplace from "@components/Marketplace";
 
 const Overview: NextPageWithLayout = () => {
 	const router = useRouter();
 	const { marketplace } = router.query;
-	const client = useCredixClient();
-	const fetchMarket = useStore((state) => state.fetchMarket);
-	const market = useStore((state) => state.market);
 
-	useEffect(() => {
-		fetchMarket(client, marketplace as string);
-	}, [client, fetchMarket, marketplace]);
-
-	const parties = [
-		{
-			name: "liquidity providers",
-			action: "invest",
-			buttonAction: "Invest",
-			buttonLink: investWithdrawRoute.path,
-			description:
-				"Stable return, flexibility to withdraw at any moment and invest in senior tranche = liquidity pool.",
-		},
-		{
-			name: "Borrowers",
-			action: "borrow",
-			buttonAction: "deals",
-			buttonLink: dealsRoute.path,
-			description:
-				"Stable return, flexibility to withdraw at any moment and invest in senior tranche = liquidity pool.",
-		},
-	];
-
-	return (
-		<main
-			id="index"
-			className="grid grid-cols-1 grid-auto-rows-min gap-y-8 md:grid-cols-12 md:gap-y-12 md:gap-x-14 justify-items-center p-4 pt-8 md:p-8 lg:max-w-6xl lg:justify-self-center"
-		>
-			<div className="text-center md:col-span-12 md:max-w-3xl grid justify-items-center">
-				<h1 className="text-5xl md:text-6xl lg:text-7xl font-semibold font-sans">
-					Welcome to Credix
-				</h1>
-				<div className="font-normal text-base md:max-w-lg">
-					The new decentralized credit marketplace connecting investors with FinTechs in emerging
-					markets
-				</div>
-			</div>
-			<div className="md:col-span-12 w-full">
-				<MarketStats market={market} />
-			</div>
-			<div className="ml-6 md:col-span-12 md:flex md:justify-between md:space-x-20 space-y-8 md:space-y-0">
-				{parties.map(({ name, action, buttonAction, buttonLink, description }) => (
-					<Card key={name} topTitle={name} title={action} offset="large">
-						<div className="mb-14 text-base">{description}</div>
-						<Link href={`/${marketplace}${buttonLink}`}>
-							<a>
-								<Button block={true} className="capitalize">
-									{buttonAction}
-								</Button>
-							</a>
-						</Link>
-					</Card>
-				))}
-			</div>
-		</main>
-	);
+	return <Marketplace marketplace={marketplace as string} />;
 };
 
 Overview.getLayout = function getLayout(page: ReactElement) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,17 +1,15 @@
+import { ReactElement } from "react";
 import Layout from "@components/Layout";
-import React, { ReactElement } from "react";
+import { NextPageWithLayout } from "pages/_app";
+import Marketplace from "@components/Marketplace";
+import { defaultMarketplace } from "@consts";
 
-// We don't actually use this page because a redirect happens but we need it anyways because otherwise we don't have an index.html to serve
-function Dummy() {
-	return <div className="px-28 py-11">Something went wrong</div>;
-}
-
-Dummy.getLayout = function getLayout(page: ReactElement) {
-	return (
-		<Layout.WithSideMenu>
-			<Layout.WithMainMenu showLogo={false}>{page}</Layout.WithMainMenu>
-		</Layout.WithSideMenu>
-	);
+const Overview: NextPageWithLayout = () => {
+	return <Marketplace marketplace={defaultMarketplace} />;
 };
 
-export default Dummy;
+Overview.getLayout = function getLayout(page: ReactElement) {
+	return <Layout.WithMainMenu>{page}</Layout.WithMainMenu>;
+};
+
+export default Overview;


### PR DESCRIPTION
This PR will:

- Copy the marketplace specific index page and move it to the root folder
- Add a new Marketplace component that's essentially the index page but takes a marketplace as a prop
- Add a fallback to "/" to the navbar logo when no marketplace route param is found
- Add a default marketplace const

## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
