### PR TITLE
fix: logo alignment

### DIFF
--- a/__tests__/__snapshots__/MainMenu.test.tsx.snap
+++ b/__tests__/__snapshots__/MainMenu.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Main menu 1`] = `
 >
   <div>
     <a
+      className="flex items-center"
       href="/"
       onClick={[Function]}
       onMouseEnter={[Function]}

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -21,7 +21,7 @@ export const MainMenu = ({ showLogo = true }: MainMenuProps) => {
 			<div>
 				{showLogo && (
 					<Link href={path}>
-						<a>
+						<a className="flex items-center">
 							<CredixLogo mode="dark" />
 						</a>
 					</Link>


### PR DESCRIPTION
This PR will:

- fix the logo alignment in the mainmenu

Before:
<img width="348" alt="afbeelding" src="https://user-images.githubusercontent.com/11614239/161723050-53984550-9df9-4f08-b7a3-530ddbfc5407.png">

After:
<img width="368" alt="afbeelding" src="https://user-images.githubusercontent.com/11614239/161723135-84072b9f-808c-49b1-b210-d5a8eac07ead.png">

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] Unit tests have been created if a new feature was added.
