### PR TITLE
feat: add management keys as comma separated list in env var

### DIFF
--- a/.env.local.dist
+++ b/.env.local.dist
@@ -1,3 +1,6 @@
 # use this env var to override the default target cluster.
 # The options are: localnet, devnet and mainnet-beta
 NEXT_PUBLIC_REACT_APP_CLUSTER=devnet
+
+# Management public keys, comma separated list.
+NEXT_PUBLIC_MANAGEMENT_KEYS=Ej5zJzej7rrUoDngsJ3jcpfuvfVyWpcDcK7uv9cE2LdL,Ej5zJzej7rrUoDngsJ3jcpfuvfVyWpcDcK7uv9cE2LdL

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,18 @@ const getClusterConfig = (): ClusterConfig => {
 	}
 };
 
+const getManagementKeys = () => {
+	const managementKeys = process.env.NEXT_PUBLIC_MANAGEMENT_KEYS;
+
+	if (managementKeys) {
+		return managementKeys.split(",")
+	}
+
+	return [
+		"Ej5zJzej7rrUoDngsJ3jcpfuvfVyWpcDcK7uv9cE2LdL",
+	]
+}
+
 export const config: Config = ((): Config => {
 	const clusterConfig = getClusterConfig();
 	// TODO: make these configurable with environment variables
@@ -61,10 +73,7 @@ export const config: Config = ((): Config => {
 		commitment: "confirmed",
 		preflightCommitment: "processed",
 	};
-	const MANAGEMENT_KEYS = [
-		"Ej5zJzej7rrUoDngsJ3jcpfuvfVyWpcDcK7uv9cE2LdL",
-		"Ej5zJzej7rrUoDngsJ3jcpfuvfVyWpcDcK7uv9cE2LdL",
-	];
+	const MANAGEMENT_KEYS = getManagementKeys();
 
 	return {
 		clusterConfig,


### PR DESCRIPTION
This PR will add:

- env var that contains the management keys in a comma separated list. 

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] Unit tests have been created if a new feature was added.

**NOTE: do not merge this PR immediately on approval. The correct keys should be added to cloudflare pages first.**
