### PR TITLE
feat: move scanning for critical vulnerabilities to devnet CD

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -28,41 +28,6 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
 
-  scan:
-    runs-on: ubuntu-latest
-    if: (github.actor != 'dependabot[bot]')
-    steps:
-      - uses: actions/checkout@v2
-
-      # Critical
-      - name: Run Trivy for critical vulnerabilities
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'fs' # Filesystem mode
-          ignore-unfixed: true # Ignore vulnerabilities with no available fix
-          format: 'table' # Table output mode as next step will report in security tab
-          severity: 'CRITICAL' # Error only on critical vulnerabilities
-          exit-code: '1' # Fail the job if a critical vulnerability with fix available is found
-
-      # Scanning
-      - name: Run Trivy for reporting all vulnerabilities
-        uses: aquasecurity/trivy-action@master
-        if: always()
-        with:
-          scan-type: 'fs' # Filesystem mode
-          ignore-unfixed: true # Ignore vulnerabilities with no available fix
-          format: 'template' # Template output mode
-          template: '@/contrib/sarif.tpl' # SARIF template to be compatible with GitHub security tab
-          output: 'trivy-results.sarif' # Output file name
-          severity: 'CRITICAL,HIGH,MEDIUM' # Report on critical/high/medium vulnerabiliies
-          exit-code: '0' # No failing as for reporting purposes
-
-      - name: Upload Trivy results
-        uses: github/codeql-action/upload-sarif@v1
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
-
   ci:
     runs-on: ubuntu-latest
     steps:
@@ -126,6 +91,16 @@ jobs:
             ${{ runner.os }}-modules-
       - name: Run yarn install
         run: yarn install
+
+      # Critical
+      - name: Run Trivy for critical vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs' # Filesystem mode
+          ignore-unfixed: true # Ignore vulnerabilities with no available fix
+          format: 'table' # Table output mode as next step will report in security tab
+          severity: 'CRITICAL' # Error only on critical vulnerabilities
+          exit-code: '1' # Fail the job if a critical vulnerability with fix available is found
 
       # Build
       - uses: actions/cache@v2


### PR DESCRIPTION
This PR will:

- update the cicd config so that CVEs only block the pipeline for devnet CD

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] Unit tests have been created if a new feature was added.
