### PR TITLE
ops: don't fail job when CVEs are found

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -100,7 +100,7 @@ jobs:
           ignore-unfixed: true # Ignore vulnerabilities with no available fix
           format: 'table' # Table output mode as next step will report in security tab
           severity: 'CRITICAL' # Error only on critical vulnerabilities
-          exit-code: '1' # Fail the job if a critical vulnerability with fix available is found
+          exit-code: '0' # Don't fail the job if a critical vulnerability with fix available is found
 
       # Build
       - uses: actions/cache@v2


### PR DESCRIPTION
This PR will:

- update the trivy scan exit code so it doesn't fail the job when CVEs are found

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] Unit tests have been created if a new feature was added.
