### PR TITLE
fix: mainmenu storybook not rendering

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -33,6 +33,7 @@ module.exports = {
 			"@components": path.resolve(__dirname, "../src/components"),
 			"@credix_types": path.resolve(__dirname, "../src/types"),
 			"@consts": path.resolve(__dirname, "../src/consts"),
+			"@config": path.resolve(__dirname, "../src/config"),
 			"@message": path.resolve(__dirname, "../src/message"),
 			"@state": path.resolve(__dirname, "../src/state"),
 			"@utils": path.resolve(__dirname, "../src/utils"),

--- a/src/components/ClientProvider.tsx
+++ b/src/components/ClientProvider.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactNode } from "react";
 import { CredixClientProvider } from "@credix/credix-client";
 import { Wallet } from "@project-serum/anchor";
 import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react";
-import { config } from "config";
+import { config } from "@config";
 
 export const ClientProvider: FC<{ children: ReactNode }> = ({ children }) => {
 	const { connection } = useConnection();

--- a/src/components/IdentityButton.tsx
+++ b/src/components/IdentityButton.tsx
@@ -10,11 +10,15 @@ import { useRouter } from "next/router";
 
 export const IdentityButton = () => {
 	const router = useRouter();
-	const { marketplace } = router.query;
 	const wallet = useWallet();
 	const client = useCredixClient();
 	const maybeFetchMarket = useStore((state) => state.maybeFetchMarket);
 	const market = useStore((state) => state.market);
+	let marketplace;
+
+	if (router) {
+		marketplace = router.query.marketplace;
+	}
 
 	useEffect(() => {
 		maybeFetchMarket(client, marketplace as string);

--- a/src/stories/MainMenu.stories.tsx
+++ b/src/stories/MainMenu.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { MainMenu } from "@components/MainMenu";
+import { ClientProvider } from "@components/ClientProvider";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -13,7 +14,10 @@ export default {
 } as ComponentMeta<typeof MainMenu>;
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
-const Template: ComponentStory<typeof MainMenu> = (args) => <MainMenu {...args} />;
-
+const Template: ComponentStory<typeof MainMenu> = (args) => (
+	<ClientProvider>
+		<MainMenu {...args} />
+	</ClientProvider>
+);
 export const Default = Template.bind({});
 Default.args = {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
 			"@components/*": ["components/*"],
 			"@credix_types/*": ["types/*"],
 			"@consts": ["consts"],
+			"@config": ["config"],
 			"@message": ["message"],
 			"@state/*": ["state/*"],
 			"@utils/*": ["utils/*"],


### PR DESCRIPTION
This PR will:
- Check if router exists before accessing the marketplace query param because the router will be null in the Storybook env
- Wrap `MainMenu` story with `ClientProvider`

Fixes: `MainMenu` story not rendering.

## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
