### PR TITLE
feat: add additional deal filtering logic

### DIFF
--- a/src/pages/[marketplace]/deals/new.tsx
+++ b/src/pages/[marketplace]/deals/new.tsx
@@ -2,7 +2,7 @@ import DealForm, { DealFormInput } from "@components/DealForm";
 import Layout from "@components/Layout";
 import { Link } from "@components/Link";
 import { useCredixClient } from "@credix/credix-client";
-import { PublicKey, TokenAmount } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
 import { getMarketsPaths } from "@utils/export.utils";
 import { numberFormatter, toProgramAmount } from "@utils/format.utils";
 import Big from "big.js";


### PR DESCRIPTION
This PR will update the existing deal filtering logic:

- Users that are borrowers and not underwriters can only see their own deals
- Users that are investors can see all deals
- Users with an active credix pass that are not borrowers can see all deals

*Replace this paragraph with a description of what this PR is changing or adding, and why.*

*List which issues are fixed by this PR. You must list at least one issue.*

## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
