### PR TITLE
feat: make marketstats and cards transparent

### DIFF
--- a/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/__tests__/__snapshots__/Card.test.tsx.snap
@@ -2,18 +2,21 @@
 
 exports[`Card with large offset 1`] = `
 <div
-  className="md:col-span-3 border border-solid rounded-[1px] border-darker w-full p-7 pt-16"
+  className="md:col-span-3 border border-solid rounded-[1px] border-darker w-full p-7 pt-16 bg-transparent"
 >
   <div
-    className="bg-credix-primary -ml-14 py-[18.5px]"
+    className="bg-transparent -ml-14 py-[18.5px] w-max relative"
   >
     <div
-      className="text-xs font-normal capitalize"
+      className="left-5 absolute w-3 h-20 z-10 bg-credix-primary"
+    />
+    <div
+      className="text-xs font-normal capitalize relative z-20"
     >
       top title
     </div>
     <div
-      className="font-sans font-semibold text-[32px] capitalize"
+      className="font-sans font-semibold text-[32px] capitalize relative z-20"
     >
       title
     </div>
@@ -28,18 +31,21 @@ exports[`Card with large offset 1`] = `
 
 exports[`Card with middle offset 1`] = `
 <div
-  className="md:col-span-3 border border-solid rounded-[1px] border-darker w-full p-7 pt-16"
+  className="md:col-span-3 border border-solid rounded-[1px] border-darker w-full p-7 pt-16 bg-transparent"
 >
   <div
-    className="bg-credix-primary -ml-12 py-[18.5px]"
+    className="bg-transparent -ml-12 py-[18.5px] w-max relative"
   >
     <div
-      className="text-xs font-normal capitalize"
+      className="left-5 absolute w-3 h-20 z-10 bg-credix-primary"
+    />
+    <div
+      className="text-xs font-normal capitalize relative z-20"
     >
       top title
     </div>
     <div
-      className="font-sans font-semibold text-[32px] capitalize"
+      className="font-sans font-semibold text-[32px] capitalize relative z-20"
     >
       title
     </div>
@@ -54,18 +60,21 @@ exports[`Card with middle offset 1`] = `
 
 exports[`Card with small offset 1`] = `
 <div
-  className="md:col-span-3 border border-solid rounded-[1px] border-darker w-full p-7 pt-16"
+  className="md:col-span-3 border border-solid rounded-[1px] border-darker w-full p-7 pt-16 bg-transparent"
 >
   <div
-    className="bg-credix-primary -ml-9 py-[18.5px]"
+    className="bg-transparent -ml-9 py-[18.5px] w-max relative"
   >
     <div
-      className="text-xs font-normal capitalize"
+      className="left-5 absolute w-3 h-20 z-10 bg-credix-primary"
+    />
+    <div
+      className="text-xs font-normal capitalize relative z-20"
     >
       top title
     </div>
     <div
-      className="font-sans font-semibold text-[32px] capitalize"
+      className="font-sans font-semibold text-[32px] capitalize relative z-20"
     >
       title
     </div>

--- a/__tests__/__snapshots__/Statistic.test.tsx.snap
+++ b/__tests__/__snapshots__/Statistic.test.tsx.snap
@@ -2,18 +2,21 @@
 
 exports[`Currency statistic 1`] = `
 <div
-  className="bg-credix-primary border border-solid border-darker rounded-[1px] font-sans h-36 w-min min-w-[16rem] md:w-full md:min-w-[12rem] ml-[21.5px] pr-5 flex items-center"
+  className="bg-transparent border border-solid border-darker rounded-[1px] font-sans h-36 w-min min-w-[16rem] md:w-full md:min-w-[12rem] ml-[21.5px] pr-5 flex items-center"
 >
   <div
-    className="bg-credix-primary ml-[-21.5px]"
+    className="bg-transparent ml-[-21.5px] relative"
   >
     <div
-      className="capitalize"
+      className="left-5 absolute w-3 h-20 z-10 bg-credix-primary"
+    />
+    <div
+      className="capitalize relative z-20"
     >
       TVL
     </div>
     <div
-      className="text-6xl font-bold"
+      className="text-6xl font-bold relative z-20"
     >
       14.8M
       <span
@@ -28,18 +31,21 @@ exports[`Currency statistic 1`] = `
 
 exports[`Percentage statistic 1`] = `
 <div
-  className="bg-credix-primary border border-solid border-darker rounded-[1px] font-sans h-36 w-min min-w-[16rem] md:w-full md:min-w-[12rem] ml-[21.5px] pr-5 flex items-center"
+  className="bg-transparent border border-solid border-darker rounded-[1px] font-sans h-36 w-min min-w-[16rem] md:w-full md:min-w-[12rem] ml-[21.5px] pr-5 flex items-center"
 >
   <div
-    className="bg-credix-primary ml-[-21.5px]"
+    className="bg-transparent ml-[-21.5px] relative"
   >
     <div
-      className="capitalize"
+      className="left-5 absolute w-3 h-20 z-10 bg-credix-primary"
+    />
+    <div
+      className="capitalize relative z-20"
     >
       Estimated APY
     </div>
     <div
-      className="text-6xl font-bold"
+      className="text-6xl font-bold relative z-20"
     >
       13.8%
       <span

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -15,10 +15,11 @@ export const Card = ({ topTitle, title, offset = "middle", children }: CardProps
 	};
 
 	return (
-		<div className="md:col-span-3 border border-solid rounded-[1px] border-darker w-full p-7 pt-16">
-			<div className={`bg-credix-primary ${offsetValues[offset]} py-[18.5px]`}>
-				<div className="text-xs font-normal capitalize">{topTitle}</div>
-				<div className="font-sans font-semibold text-[32px] capitalize">{title}</div>
+		<div className="md:col-span-3 border border-solid rounded-[1px] border-darker w-full p-7 pt-16 bg-transparent">
+			<div className={`bg-transparent ${offsetValues[offset]} py-[18.5px] w-max relative`}>
+				<div className="left-5 absolute w-3 h-20 z-10 bg-credix-primary"></div>
+				<div className="text-xs font-normal capitalize relative z-20">{topTitle}</div>
+				<div className="font-sans font-semibold text-[32px] capitalize relative z-20">{title}</div>
 			</div>
 			<div className="text-base">{children}</div>
 		</div>

--- a/src/components/Statistic.tsx
+++ b/src/components/Statistic.tsx
@@ -24,10 +24,11 @@ export const Statistic = ({ label, value, currency, isPercentage = false }: Stat
 	}, [formatter, value]);
 
 	return (
-		<div className="bg-credix-primary border border-solid border-darker rounded-[1px] font-sans h-36 w-min min-w-[16rem] md:w-full md:min-w-[12rem] ml-[21.5px] pr-5 flex items-center">
-			<div className="bg-credix-primary ml-[-21.5px]">
-				<div className="capitalize">{label}</div>
-				<div className="text-6xl font-bold">
+		<div className="bg-transparent border border-solid border-darker rounded-[1px] font-sans h-36 w-min min-w-[16rem] md:w-full md:min-w-[12rem] ml-[21.5px] pr-5 flex items-center">
+			<div className="bg-transparent ml-[-21.5px] relative">
+				<div className="left-5 absolute w-3 h-20 z-10 bg-credix-primary"></div>
+				<div className="capitalize relative z-20">{label}</div>
+				<div className="text-6xl font-bold relative z-20">
 					{formattedValue}
 					<span className="text-sm font-normal">{currency}</span>
 				</div>


### PR DESCRIPTION
This PR will: 

- Make the cards on the index page transparent so that the background SVG is visible

![afbeelding](https://user-images.githubusercontent.com/11614239/164458251-1e1aae8a-e7ad-4914-9501-152f75bef4e3.png)


*List which issues are fixed by this PR. You must list at least one issue.*

## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
