### PR TITLE
fix: removed ci dep from cd devnet cron

### DIFF
--- a/.github/workflows/cd-devnet-cron.yaml
+++ b/.github/workflows/cd-devnet-cron.yaml
@@ -9,12 +9,13 @@ jobs:
   cd-devnet:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/devnet'
-    needs: [ci]
     environment:
       name: devnet
       url: https://app-v2.dev.credix.finance
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: devnet
 
       # Install
       - name: Use Node.js 14.17


### PR DESCRIPTION
*This PR fixes the devnet cron deploy.*

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] Unit tests have been created if a new feature was added.
