### PR TITLE
feat: update deal-card element spacing

### DIFF
--- a/src/components/DealCard.tsx
+++ b/src/components/DealCard.tsx
@@ -22,8 +22,8 @@ export const DealCard: FunctionComponent<DealCardProps> = ({ marketplace, deal, 
 				})}
 				icon="chevron-left-square"
 			/>
-			<div className="text-4xl font-sans pt-3 pb-9 break-words">{deal.name}</div>
-			<div className="bg-neutral-0 py-10 px-14 ">{children}</div>
+			<div className="text-4xl font-sans mt-4 break-words">{deal.name}</div>
+			<div className="bg-neutral-0 py-10 px-14 mt-8">{children}</div>
 		</div>
 	);
 };


### PR DESCRIPTION
This PR will:

- update the spacing between the deal-card elements

based on the following:
<img width="839" alt="image" src="https://user-images.githubusercontent.com/11614239/166226557-798eebd6-8b30-4db4-b021-fa8213dec6f2.png">

## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
