### PR TITLE
feat: give pagination buttons less height

### DIFF
--- a/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Default 1`] = `
     title="Previous Page"
   >
     <button
-      className="ant-pagination-item-link border-none bg-transparent w-[39px] h-[36px] grid place-content-center"
+      className="ant-pagination-item-link border-none bg-transparent w-[39px] h-8 grid place-content-center"
       tabIndex={-1}
       type="button"
     >
@@ -44,7 +44,7 @@ exports[`Default 1`] = `
     title={1}
   >
     <a
-      className="ant-pagination-item-link border-none bg-white w-[39px] h-[36px] font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
+      className="ant-pagination-item-link border-none bg-white w-[39px] h-8 font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
       rel="nofollow"
     >
       <span>
@@ -60,7 +60,7 @@ exports[`Default 1`] = `
     title={2}
   >
     <a
-      className="ant-pagination-item-link border-none bg-white w-[39px] h-[36px] font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
+      className="ant-pagination-item-link border-none bg-white w-[39px] h-8 font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
       rel="nofollow"
     >
       <span>
@@ -76,7 +76,7 @@ exports[`Default 1`] = `
     title={3}
   >
     <a
-      className="ant-pagination-item-link border-none bg-white w-[39px] h-[36px] font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
+      className="ant-pagination-item-link border-none bg-white w-[39px] h-8 font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
       rel="nofollow"
     >
       <span>
@@ -92,7 +92,7 @@ exports[`Default 1`] = `
     title={4}
   >
     <a
-      className="ant-pagination-item-link border-none bg-white w-[39px] h-[36px] font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
+      className="ant-pagination-item-link border-none bg-white w-[39px] h-8 font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
       rel="nofollow"
     >
       <span>
@@ -108,7 +108,7 @@ exports[`Default 1`] = `
     title={5}
   >
     <a
-      className="ant-pagination-item-link border-none bg-white w-[39px] h-[36px] font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
+      className="ant-pagination-item-link border-none bg-white w-[39px] h-8 font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
       rel="nofollow"
     >
       <span>
@@ -125,7 +125,7 @@ exports[`Default 1`] = `
     title="Next Page"
   >
     <button
-      className="ant-pagination-item-link border-none bg-transparent w-[39px] h-[36px] grid place-content-center"
+      className="ant-pagination-item-link border-none bg-transparent w-[39px] h-8 grid place-content-center"
       tabIndex={-1}
       type="button"
     >
@@ -164,7 +164,7 @@ exports[`With more 1`] = `
     title="Previous Page"
   >
     <button
-      className="ant-pagination-item-link border-none bg-transparent w-[39px] h-[36px] grid place-content-center"
+      className="ant-pagination-item-link border-none bg-transparent w-[39px] h-8 grid place-content-center"
       tabIndex={-1}
       type="button"
     >
@@ -193,7 +193,7 @@ exports[`With more 1`] = `
     title={1}
   >
     <a
-      className="ant-pagination-item-link border-none bg-white w-[39px] h-[36px] font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
+      className="ant-pagination-item-link border-none bg-white w-[39px] h-8 font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
       rel="nofollow"
     >
       <span>
@@ -209,7 +209,7 @@ exports[`With more 1`] = `
     title={2}
   >
     <a
-      className="ant-pagination-item-link border-none bg-white w-[39px] h-[36px] font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
+      className="ant-pagination-item-link border-none bg-white w-[39px] h-8 font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
       rel="nofollow"
     >
       <span>
@@ -225,7 +225,7 @@ exports[`With more 1`] = `
     title={3}
   >
     <a
-      className="ant-pagination-item-link border-none bg-white w-[39px] h-[36px] font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
+      className="ant-pagination-item-link border-none bg-white w-[39px] h-8 font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
       rel="nofollow"
     >
       <span>
@@ -241,7 +241,7 @@ exports[`With more 1`] = `
     title={4}
   >
     <a
-      className="ant-pagination-item-link border-none bg-white w-[39px] h-[36px] font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
+      className="ant-pagination-item-link border-none bg-white w-[39px] h-8 font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
       rel="nofollow"
     >
       <span>
@@ -257,7 +257,7 @@ exports[`With more 1`] = `
     title={5}
   >
     <a
-      className="ant-pagination-item-link border-none bg-white w-[39px] h-[36px] font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
+      className="ant-pagination-item-link border-none bg-white w-[39px] h-8 font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
       rel="nofollow"
     >
       <span>
@@ -273,7 +273,7 @@ exports[`With more 1`] = `
     title="Next 5 Pages"
   >
     <a
-      className="ant-pagination-item-link text-neutral-100 border-none bg-transparent w-[39px] h-[36px] grid place-content-center"
+      className="ant-pagination-item-link text-neutral-100 border-none bg-transparent w-[39px] h-8 grid place-content-center"
     >
       <svg
         className="w-6 h-5 fill-current"
@@ -309,7 +309,7 @@ exports[`With more 1`] = `
     title={10}
   >
     <a
-      className="ant-pagination-item-link border-none bg-white w-[39px] h-[36px] font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
+      className="ant-pagination-item-link border-none bg-white w-[39px] h-8 font-mono grid place-content-center text-lg font-medium hover:text-neutral-100"
       rel="nofollow"
     >
       <span>
@@ -326,7 +326,7 @@ exports[`With more 1`] = `
     title="Next Page"
   >
     <button
-      className="ant-pagination-item-link border-none bg-transparent w-[39px] h-[36px] grid place-content-center"
+      className="ant-pagination-item-link border-none bg-transparent w-[39px] h-8 grid place-content-center"
       tabIndex={-1}
       type="button"
     >

--- a/src/components/PageItem.tsx
+++ b/src/components/PageItem.tsx
@@ -14,7 +14,7 @@ export const PageItem = ({ page, type, originalElement }: PageItemProps) => {
 				originalElement as React.ReactElement,
 				{
 					className:
-						"ant-pagination-item-link border-none bg-transparent w-[39px] h-[36px] grid place-content-center",
+						"ant-pagination-item-link border-none bg-transparent w-[39px] h-8 grid place-content-center",
 				},
 				<Icon name="chevron-left" size={IconDimension.SMALL} />
 			);
@@ -23,7 +23,7 @@ export const PageItem = ({ page, type, originalElement }: PageItemProps) => {
 				originalElement as React.ReactElement,
 				{
 					className:
-						"ant-pagination-item-link border-none bg-white w-[39px] h-[36px] font-mono grid place-content-center text-lg font-medium hover:text-neutral-100",
+						"ant-pagination-item-link border-none bg-white w-[39px] h-8 font-mono grid place-content-center text-lg font-medium hover:text-neutral-100",
 				},
 				<span>{page}</span>
 			);
@@ -32,7 +32,7 @@ export const PageItem = ({ page, type, originalElement }: PageItemProps) => {
 				originalElement as React.ReactElement,
 				{
 					className:
-						"ant-pagination-item-link border-none bg-transparent w-[39px] h-[36px] grid place-content-center",
+						"ant-pagination-item-link border-none bg-transparent w-[39px] h-8 grid place-content-center",
 				},
 				<Icon name="chevron-right" size={IconDimension.SMALL} />
 			);
@@ -42,7 +42,7 @@ export const PageItem = ({ page, type, originalElement }: PageItemProps) => {
 				originalElement as React.ReactElement,
 				{
 					className:
-						"ant-pagination-item-link text-neutral-100 border-none bg-transparent w-[39px] h-[36px] grid place-content-center",
+						"ant-pagination-item-link text-neutral-100 border-none bg-transparent w-[39px] h-8 grid place-content-center",
 				},
 				<Icon name="ellipsis" className="w-6 h-5" />
 			);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -111,7 +111,7 @@ body {
 }
 
 .ant-table-pagination > * {
-	@apply w-[39px] h-[36px] border-none m-0 rounded-none !important;
+	@apply w-[39px] h-8 border-none m-0 rounded-none !important;
 }
 
 .ant-pagination-item-active a,


### PR DESCRIPTION
This PR will:

- update the height of the pagination buttons

based on the following:
<img width="516" alt="image" src="https://user-images.githubusercontent.com/11614239/166226647-91cd8282-e068-4eb1-9f57-84935d43e020.png">

## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
