### PR TITLE
feat: give table cells more x/y padding

### DIFF
--- a/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/__tests__/__snapshots__/Table.test.tsx.snap
@@ -173,7 +173,7 @@ exports[`Table headers with icons 1`] = `
                     style={Object {}}
                   >
                     <div
-                      className="space-x-1.5 flex items-center "
+                      className="space-x-1 flex items-center "
                     >
                       <svg
                         className="w-4 h-4 fill-current"
@@ -200,7 +200,7 @@ exports[`Table headers with icons 1`] = `
                     style={Object {}}
                   >
                     <div
-                      className="space-x-1.5 flex items-center "
+                      className="space-x-1 flex items-center "
                     >
                       <svg
                         className="w-4 h-4 fill-current"
@@ -227,7 +227,7 @@ exports[`Table headers with icons 1`] = `
                     style={Object {}}
                   >
                     <div
-                      className="space-x-1.5 flex items-center "
+                      className="space-x-1 flex items-center "
                     >
                       <svg
                         className="w-4 h-4 fill-current"

--- a/src/components/TableHeaderCell.tsx
+++ b/src/components/TableHeaderCell.tsx
@@ -9,7 +9,7 @@ export interface TableHeaderCellProps {
 
 export const TableHeaderCell = ({ icon, label, className = "" }: TableHeaderCellProps) => {
 	return (
-		<div className={`space-x-1.5 flex items-center ${className}`}>
+		<div className={`space-x-1 flex items-center ${className}`}>
 			<Icon name={icon} size={IconDimension.SMALL} />
 			<span>{label}</span>
 		</div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -103,7 +103,7 @@ body {
 }
 
 .ant-table-cell {
-	@apply bg-neutral-0 font-bold text-base !important;
+	@apply bg-neutral-0 font-bold text-base px-6 py-4 !important;
 }
 
 .ant-table-pagination {


### PR DESCRIPTION
This PR will:

- update the table cell padding

based on: 
<img width="1208" alt="image" src="https://user-images.githubusercontent.com/11614239/166226940-46e00939-20d5-4975-976a-7f38e708cbf7.png">


## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
