### PR TITLE
feat: tweak tag height and padding

### DIFF
--- a/__tests__/__snapshots__/Tag.test.tsx.snap
+++ b/__tests__/__snapshots__/Tag.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Active tag 1`] = `
 <div
-  className="py-[2px] px-3 border rounded-full min-w-[88px] font-semibold w-min flex justify-center bg-neutral-60 border-neutral-60 text-credix-primary"
+  className="py-[2px] p-2 h-8 border rounded-full min-w-[88px] font-semibold w-min flex justify-center items-center bg-neutral-60 border-neutral-60 text-credix-primary"
 >
   Active
 </div>
@@ -10,7 +10,7 @@ exports[`Active tag 1`] = `
 
 exports[`Ended tag 1`] = `
 <div
-  className="py-[2px] px-3 border rounded-full min-w-[88px] font-semibold w-min flex justify-center bg-credix-primary border-solid border-darker color-darker"
+  className="py-[2px] p-2 h-8 border rounded-full min-w-[88px] font-semibold w-min flex justify-center items-center bg-credix-primary border-solid border-darker color-darker"
 >
   Ended
 </div>
@@ -18,7 +18,7 @@ exports[`Ended tag 1`] = `
 
 exports[`Inactive tag 1`] = `
 <div
-  className="py-[2px] px-3 border rounded-full min-w-[88px] font-semibold w-min flex justify-center bg-neutral-10 border-neutral-10"
+  className="py-[2px] p-2 h-8 border rounded-full min-w-[88px] font-semibold w-min flex justify-center items-center bg-neutral-10 border-neutral-10"
 >
   Inactive
 </div>
@@ -26,7 +26,7 @@ exports[`Inactive tag 1`] = `
 
 exports[`Pending tag 1`] = `
 <div
-  className="py-[2px] px-3 border rounded-full min-w-[88px] font-semibold w-min flex justify-center bg-neutral-40 border-neutral-40 text-credix-primary"
+  className="py-[2px] p-2 h-8 border rounded-full min-w-[88px] font-semibold w-min flex justify-center items-center bg-neutral-40 border-neutral-40 text-credix-primary"
 >
   Pending
 </div>

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -16,7 +16,7 @@ const tagTypeStyles = {
 export const Tag = ({ children, type }: TagProps) => {
 	return (
 		<div
-			className={`py-[2px] px-3 border rounded-full min-w-[88px] font-semibold w-min flex justify-center ${tagTypeStyles[type]}`}
+			className={`py-[2px] p-2 h-8 border rounded-full min-w-[88px] font-semibold w-min flex justify-center items-center ${tagTypeStyles[type]}`}
 		>
 			{children}
 		</div>


### PR DESCRIPTION
This PR will:

- update the Tag height and padding

based on:
<img width="877" alt="image" src="https://user-images.githubusercontent.com/11614239/166227203-76032b97-e4ab-4dd4-82c8-356fa1652f7c.png">

## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
