### PR TITLE
Input field UI tweaks

### DIFF
--- a/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/__tests__/__snapshots__/Input.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Default input 1`] = `
                   className="ant-form-item-control-input-content"
                 >
                   <input
-                    className="ant-input ant-input-lg border-[0.5px] rounded-[1px] focus:shadow-none disabled:border-neutral-60/40 border-neutral-60 focus:ring-neutral-100 focus:border-neutral-100"
+                    className="ant-input ant-input-lg border-[0.5px] rounded-[1px] h-12 focus:shadow-none disabled:border-neutral-60/40 border-neutral-60 focus:ring-neutral-100 focus:border-neutral-100"
                     disabled={false}
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -113,7 +113,7 @@ exports[`Disabled input 1`] = `
                   className="ant-form-item-control-input-content"
                 >
                   <input
-                    className="ant-input ant-input-disabled ant-input-lg border-[0.5px] rounded-[1px] focus:shadow-none disabled:border-neutral-60/40 border-neutral-60 focus:ring-neutral-100 focus:border-neutral-100"
+                    className="ant-input ant-input-disabled ant-input-lg border-[0.5px] rounded-[1px] h-12 focus:shadow-none disabled:border-neutral-60/40 border-neutral-60 focus:ring-neutral-100 focus:border-neutral-100"
                     disabled={true}
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -209,11 +209,6 @@ exports[`Input with description 1`] = `
           className="ant-form-item-control-input-content"
         >
           <div
-            className="font-normal text-sm mt-0 mb-[10px]"
-          >
-            This is a short information text that gives more details about the question.
-          </div>
-          <div
             className="ant-row ant-form-item mb-0"
             style={Object {}}
           >
@@ -228,7 +223,7 @@ exports[`Input with description 1`] = `
                   className="ant-form-item-control-input-content"
                 >
                   <input
-                    className="ant-input ant-input-lg border-[0.5px] rounded-[1px] focus:shadow-none disabled:border-neutral-60/40 border-neutral-60 focus:ring-neutral-100 focus:border-neutral-100"
+                    className="ant-input ant-input-lg border-[0.5px] rounded-[1px] h-12 focus:shadow-none disabled:border-neutral-60/40 border-neutral-60 focus:ring-neutral-100 focus:border-neutral-100"
                     disabled={false}
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -241,6 +236,11 @@ exports[`Input with description 1`] = `
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="font-normal text-sm mt-2"
+          >
+            This is a short information text that gives more details about the question.
           </div>
         </div>
       </div>
@@ -295,7 +295,7 @@ exports[`Input with error feedback 1`] = `
                   className="ant-form-item-control-input-content"
                 >
                   <input
-                    className="ant-input ant-input-lg border-[0.5px] rounded-[1px] focus:shadow-none disabled:border-neutral-60/40 border-error focus:ring-error focus:border-error"
+                    className="ant-input ant-input-lg border-[0.5px] rounded-[1px] h-12 focus:shadow-none disabled:border-neutral-60/40 border-error focus:ring-error focus:border-error"
                     disabled={false}
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -362,7 +362,7 @@ exports[`Input with text 1`] = `
                   className="ant-form-item-control-input-content"
                 >
                   <input
-                    className="ant-input ant-input-lg border-[0.5px] rounded-[1px] focus:shadow-none disabled:border-neutral-60/40 border-neutral-60 focus:ring-neutral-100 focus:border-neutral-100"
+                    className="ant-input ant-input-lg border-[0.5px] rounded-[1px] h-12 focus:shadow-none disabled:border-neutral-60/40 border-neutral-60 focus:ring-neutral-100 focus:border-neutral-100"
                     disabled={false}
                     onBlur={[Function]}
                     onChange={[Function]}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -110,7 +110,6 @@ export const Input = ({
 			required={required}
 			className={labelClassName}
 		>
-			{description && <div className="font-normal text-sm mt-0 mb-[10px]">{description}</div>}
 			<Form.Item name={name} className="mb-0" rules={rules}>
 				<AntdInput
 					disabled={disabled}
@@ -122,6 +121,7 @@ export const Input = ({
 					{children}
 				</AntdInput>
 			</Form.Item>
+			{description && <div className="font-normal text-sm mt-2">{description}</div>}
 		</Form.Item>
 	);
 };

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -83,7 +83,7 @@ export const Input = ({
 	}
 
 	const inputClassName = [
-		"border-[0.5px] rounded-[1px] focus:shadow-none disabled:border-neutral-60/40",
+		"border-[0.5px] rounded-[1px] h-12 focus:shadow-none disabled:border-neutral-60/40",
 		hasFeedback && validateStatus == "error"
 			? "border-error focus:ring-error focus:border-error"
 			: "border-neutral-60 focus:ring-neutral-100 focus:border-neutral-100",

--- a/src/components/RepayDealForm.tsx
+++ b/src/components/RepayDealForm.tsx
@@ -132,7 +132,7 @@ const RepayDealForm: FunctionComponent<RepayDealFormProps> = ({
 					})}
 					type="number"
 					suffix={
-						<div onClick={onAddMax} className="pr-6 hover:cursor-pointer hover:font-semibold">
+						<div onClick={onAddMax} className="pr-4 hover:cursor-pointer hover:font-semibold">
 							MAX
 						</div>
 					}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -175,7 +175,7 @@ body {
 }
 
 .ant-form-item-control-input-content .ant-input {
-	@apply pl-4 pr-[25px] py-3 font-medium text-base bg-neutral-0 placeholder-neutral-100/70 !important;
+	@apply px-4 py-3 font-medium text-base bg-neutral-0 placeholder-neutral-100/70 !important;
 }
 
 .ant-form-item-control-input-content .ant-input-suffix {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -71,7 +71,7 @@ body {
 	@apply border rounded rounded-l-none border-neutral-40 bg-neutral-0 !important;
 }
 .ant-input-affix-wrapper.ant-input-affix-wrapper-lg .ant-input {
-	@apply py-4 px-[14.5px] bg-neutral-0 font-normal !important;
+	@apply py-4 px-4 bg-neutral-0 font-normal !important;
 }
 .ant-input-affix-wrapper:not(.ant-input-affix-wrapper-disabled):hover {
 	@apply border border-neutral-60 !important;
@@ -266,15 +266,15 @@ body {
 }
 
 .ant-select-arrow {
-	@apply w-max h-max -mt-3 mr-4 z-10 !important;
+	@apply w-max h-max -mt-3 right-4 z-10 !important;
 }
 
 .ant-select-single:not(.ant-select-customize-input) .ant-select-selector {
-	@apply pl-6 pr-10 !important;
+	@apply pl-4 pr-10 !important;
 }
 
 .ant-select-selection-item {
-	@apply pr-5 text-base !important;
+	@apply pr-4 text-base !important;
 }
 
 .ant-input-group.ant-input-group-compact {


### PR DESCRIPTION
This PR will:

- update the height and padding of the input fields
- Make the repay interest/principal input group more consistent

based on:
<img width="686" alt="image" src="https://user-images.githubusercontent.com/11614239/166227334-1bc226ab-ef53-4eb4-a3c8-53ba35a5012a.png">
and:
<img width="883" alt="image" src="https://user-images.githubusercontent.com/11614239/166227344-c926d961-8d85-4835-8aa2-984a4f6d26f1.png">


*List which issues are fixed by this PR. You must list at least one issue.*

## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
