### PR TITLE
feat: buttons have one size and are rounded

### DIFF
--- a/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`Outline button 1`] = `
 <button
-  className="ant-btn ant-btn-default rounded-[1px] border text-shadow-none shadow-none flex items-center justify-center gap-2 px-[25px] 
+  className="ant-btn ant-btn-default rounded-md h-12 text-base font-medium border text-shadow-none shadow-none flex items-center justify-center gap-2 px-6 
 				bg-credix-primary text-neutral-100 border-neutral-100
 				hover:text-neutral-60 hover:border-neutral-60
 				active:text-neutral-40 active:border-neutral-60
 				disabled:border-action-disable disabled:text-disabled
-			 text-base font-medium h-[42px]"
+			"
   onClick={[Function]}
   type="button"
 >
@@ -19,12 +19,12 @@ exports[`Outline button 1`] = `
 
 exports[`Outline button disabled 1`] = `
 <button
-  className="ant-btn ant-btn-default rounded-[1px] border text-shadow-none shadow-none flex items-center justify-center gap-2 px-[25px] 
+  className="ant-btn ant-btn-default rounded-md h-12 text-base font-medium border text-shadow-none shadow-none flex items-center justify-center gap-2 px-6 
 				bg-credix-primary text-neutral-100 border-neutral-100
 				hover:text-neutral-60 hover:border-neutral-60
 				active:text-neutral-40 active:border-neutral-60
 				disabled:border-action-disable disabled:text-disabled
-			 text-base font-medium h-[42px]"
+			"
   disabled={true}
   onClick={[Function]}
   type="button"
@@ -37,12 +37,12 @@ exports[`Outline button disabled 1`] = `
 
 exports[`Outline button with icon 1`] = `
 <button
-  className="ant-btn ant-btn-default rounded-[1px] border text-shadow-none shadow-none flex items-center justify-center gap-2 px-[25px] 
+  className="ant-btn ant-btn-default rounded-md h-12 text-base font-medium border text-shadow-none shadow-none flex items-center justify-center gap-2 px-6 
 				bg-credix-primary text-neutral-100 border-neutral-100
 				hover:text-neutral-60 hover:border-neutral-60
 				active:text-neutral-40 active:border-neutral-60
 				disabled:border-action-disable disabled:text-disabled
-			 text-base font-medium h-[42px]"
+			"
   onClick={[Function]}
   type="button"
 >
@@ -63,12 +63,12 @@ exports[`Outline button with icon 1`] = `
 
 exports[`Primary button 1`] = `
 <button
-  className="ant-btn ant-btn-primary rounded-[1px] border text-shadow-none shadow-none flex items-center justify-center gap-2 px-[25px] 
+  className="ant-btn ant-btn-primary rounded-md h-12 text-base font-medium border text-shadow-none shadow-none flex items-center justify-center gap-2 px-6 
 				bg-action-primary border-action-primary text-credix-primary
 				hover:bg-neutral-60 hover:border-neutral-60
 				active:bg-neutral-40 active:border-neutral-40 active:text-neutral-100
 				disabled:bg-action-disable disabled:border-transparent disabled:text-disabled
-			 text-base font-medium h-[42px]"
+			"
   onClick={[Function]}
   type="button"
 >
@@ -80,12 +80,12 @@ exports[`Primary button 1`] = `
 
 exports[`Primary button disabled 1`] = `
 <button
-  className="ant-btn ant-btn-primary rounded-[1px] border text-shadow-none shadow-none flex items-center justify-center gap-2 px-[25px] 
+  className="ant-btn ant-btn-primary rounded-md h-12 text-base font-medium border text-shadow-none shadow-none flex items-center justify-center gap-2 px-6 
 				bg-action-primary border-action-primary text-credix-primary
 				hover:bg-neutral-60 hover:border-neutral-60
 				active:bg-neutral-40 active:border-neutral-40 active:text-neutral-100
 				disabled:bg-action-disable disabled:border-transparent disabled:text-disabled
-			 text-base font-medium h-[42px]"
+			"
   disabled={true}
   onClick={[Function]}
   type="button"
@@ -98,12 +98,12 @@ exports[`Primary button disabled 1`] = `
 
 exports[`Primary button with icon 1`] = `
 <button
-  className="ant-btn ant-btn-primary rounded-[1px] border text-shadow-none shadow-none flex items-center justify-center gap-2 px-[25px] 
+  className="ant-btn ant-btn-primary rounded-md h-12 text-base font-medium border text-shadow-none shadow-none flex items-center justify-center gap-2 px-6 
 				bg-action-primary border-action-primary text-credix-primary
 				hover:bg-neutral-60 hover:border-neutral-60
 				active:bg-neutral-40 active:border-neutral-40 active:text-neutral-100
 				disabled:bg-action-disable disabled:border-transparent disabled:text-disabled
-			 text-base font-medium h-[42px]"
+			"
   onClick={[Function]}
   type="button"
 >

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -4,10 +4,6 @@ import { ButtonProps as AntButtonProps } from "antd/lib/button";
 
 interface ButtonProps {
 	/**
-	 * Optional size of the button.
-	 */
-	size?: AntButtonProps["size"];
-	/**
 	 * Controls whether the button is disabled or not.
 	 */
 	disabled?: AntButtonProps["disabled"];
@@ -51,28 +47,14 @@ export const buttonTypeStyles = {
 			`,
 };
 
-export const buttonSizeStyles = {
-	small: "text-sm font-semibold h-10",
-	middle: "text-base font-medium h-[42px]",
-	large: "text-lg font-semibold h-[50px]",
-};
-
 export const defaultButtonStyles =
-	"rounded-[1px] border text-shadow-none shadow-none flex items-center justify-center gap-2 px-[25px]";
+	"rounded-md h-12 text-base font-medium border text-shadow-none shadow-none flex items-center justify-center gap-2 px-6";
 
-export const Button = ({
-	children,
-	className,
-	size = "middle",
-	type = "primary",
-	...props
-}: ButtonProps) => {
-	className = [defaultButtonStyles, buttonTypeStyles[type], buttonSizeStyles[size], className]
-		.filter(Boolean)
-		.join(" ");
+export const Button = ({ children, className, type = "primary", ...props }: ButtonProps) => {
+	className = [defaultButtonStyles, buttonTypeStyles[type], className].filter(Boolean).join(" ");
 
 	return (
-		<AntdButton className={className} size={size} type={type} {...props}>
+		<AntdButton className={className} type={type} {...props}>
 			{children}
 		</AntdButton>
 	);

--- a/src/components/Marketplace.tsx
+++ b/src/components/Marketplace.tsx
@@ -5,12 +5,7 @@ import { useCredixClient } from "@credix/credix-client";
 import Link from "next/link";
 import { dealsRoute, investWithdrawRoute, borrowerTypeformId, investorTypeformId } from "@consts";
 import { useStore } from "@state/useStore";
-import {
-	Button,
-	buttonSizeStyles,
-	buttonTypeStyles,
-	defaultButtonStyles,
-} from "@components/Button";
+import { Button, buttonTypeStyles, defaultButtonStyles } from "@components/Button";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { PopupButton } from "@typeform/embed-react";
 
@@ -113,7 +108,7 @@ const Marketplace: FunctionComponent<MarketplaceProps> = (props) => {
 						) : (
 							<PopupButton
 								id={typeformId}
-								className={`${defaultButtonStyles} ${buttonTypeStyles["primary"]} ${buttonSizeStyles["middle"]} w-full capitalize hover:cursor-pointer border-b-0 border-r-0`}
+								className={`${defaultButtonStyles} ${buttonTypeStyles["primary"]}} w-full capitalize hover:cursor-pointer border-b-0 border-r-0`}
 							>
 								{buttonAction}
 							</PopupButton>

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -75,7 +75,6 @@ export const WalletButton = ({ className = "" }: WalletButtonProps) => {
 	if (!wallet && !publicKey) {
 		return (
 			<Button
-				size="large"
 				onClick={() => setVisible(true)}
 				icon={<Icon name="wallet" size={IconDimension.MIDDLE} />}
 				className={className}
@@ -117,7 +116,6 @@ export const WalletButton = ({ className = "" }: WalletButtonProps) => {
 		<Dropdown overlay={menu} trigger={["click"]}>
 			<Button
 				type="default"
-				size="large"
 				onClick={(event) => event.preventDefault()}
 				icon={<WalletIcon wallet={wallet} className="w-6" />}
 				className={`${className} w-56`}

--- a/src/pages/[marketplace]/deals/index.tsx
+++ b/src/pages/[marketplace]/deals/index.tsx
@@ -87,7 +87,7 @@ const Deals: NextPageWithLayout = () => {
 					{isRepayable ? (
 						<Link href={path}>
 							<a>
-								<Button size="large">
+								<Button>
 									<span className="capitalize">
 										{intl.formatMessage({
 											defaultMessage: "repay",
@@ -100,7 +100,7 @@ const Deals: NextPageWithLayout = () => {
 					) : (
 						<Link href={path}>
 							<a className="w-full">
-								<Button size="large" className="w-full">
+								<Button className="w-full">
 									<span className="capitalize">
 										{intl.formatMessage({
 											defaultMessage: "info",
@@ -164,7 +164,7 @@ const Deals: NextPageWithLayout = () => {
 	const investButton = (
 		<Link href={`/${marketplace}/invest-withdraw`}>
 			<a>
-				<Button size="large" icon={<Icon name="plus-square" className="w-5 h-5" />}>
+				<Button icon={<Icon name="plus-square" className="w-5 h-5" />}>
 					<span className="text-lg capitalize">
 						{intl.formatMessage({ defaultMessage: "invest", description: "Deals: invest button" })}
 					</span>
@@ -176,7 +176,7 @@ const Deals: NextPageWithLayout = () => {
 	const newDealButton = (
 		<Link href={`/${marketplace}/deals/new`}>
 			<a>
-				<Button size="large" icon={<Icon name="plus-square" className="w-5 h-5" />}>
+				<Button icon={<Icon name="plus-square" className="w-5 h-5" />}>
 					<span className="text-lg capitalize">
 						{intl.formatMessage({
 							defaultMessage: "create new deal",

--- a/src/pages/[marketplace]/deals/show.tsx
+++ b/src/pages/[marketplace]/deals/show.tsx
@@ -50,12 +50,7 @@ const Show: NextPageWithLayout = () => {
 		<DealCard marketplace={marketplace as string} deal={deal}>
 			<DealDetails deal={deal} />
 			{isAdmin && deal.isPending() && (
-				<Button
-					type="default"
-					size="large"
-					className="mt-14 bg-neutral-0 capitalize"
-					onClick={activateDeal}
-				>
+				<Button type="default" className="mt-14 bg-neutral-0 capitalize" onClick={activateDeal}>
 					{intl.formatMessage({
 						defaultMessage: "activate deal",
 						description: "Activate deal: button",

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -33,7 +33,7 @@ body {
 }
 
 .identity-button > button {
-	@apply bg-credix-primary text-neutral-100 h-[50px] flex justify-center items-center;
+	@apply rounded-md bg-credix-primary text-neutral-100 h-12 flex justify-center items-center;
 }
 
 .identity-button > button > svg {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,7 +15,7 @@ module.exports = {
 			gridTemplateColumns: {
 				layout: "min-content 1fr",
 			},
-			borderRadius: { DEFAULT: "0.0625rem" },
+			borderRadius: { DEFAULT: "0.0625rem", md: "0.25rem" },
 			colors: theme.colors,
 			fontFamily: {
 				sans: [


### PR DESCRIPTION
This PR will:

- remove the `size` prop from buttons
- give a borderradius of 4px to buttons

based on:
<img width="619" alt="image" src="https://user-images.githubusercontent.com/11614239/166227465-3c14e5a4-5822-4aaa-85a6-97828faaee6b.png">


## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
