### PR TITLE
feat: skip ci when draft pr

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -7,11 +7,16 @@ on:
       - devnet
       - mainnet
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    if: (github.actor != 'dependabot[bot]')
+    if: (github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false)
     permissions:
       actions: read
       contents: read
@@ -30,6 +35,7 @@ jobs:
 
   ci:
     runs-on: ubuntu-latest
+    if: (github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
*This PR disables CI run when draft PR.*

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
