### PR TITLE
fix: add pre-mainnet branch to cicd

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - localnet
       - devnet
+      - pre-mainnet
       - mainnet
   pull_request:
     types:


### PR DESCRIPTION
*This PR fixes pre-mainnet cicd.*

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
