### PR TITLE
fix: interest paid and date cells wrapping

### DIFF
--- a/src/pages/[marketplace]/deals/index.tsx
+++ b/src/pages/[marketplace]/deals/index.tsx
@@ -60,7 +60,7 @@ const Deals: NextPageWithLayout = () => {
 			icon: "calendar",
 			dataIndex: "date",
 			key: "date",
-			width: 150,
+			width: 160,
 			render: (text) => (
 				<span className="font-medium text-lg">
 					{text && formatTimestamp(text, locales as string[])}
@@ -71,7 +71,7 @@ const Deals: NextPageWithLayout = () => {
 			title: "Interest paid",
 			dataIndex: "paid",
 			key: "paid",
-			width: 160,
+			width: 180,
 			render: (value: number) => <Slider value={value} fullLabel="Full" />,
 		},
 		{


### PR DESCRIPTION
This PR will:

- fix a visual regression caused by giving the table cells more padding

before:
<img width="522" alt="image" src="https://user-images.githubusercontent.com/11614239/166641700-14db6761-093d-4c29-bbb5-81d2149e6ad1.png">

after:
<img width="479" alt="image" src="https://user-images.githubusercontent.com/11614239/166641750-3f2af47b-aa9f-4865-a03e-20b1be927b7f.png">

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] Unit tests have been created if a new feature was added.
- [x] Translations have been added and extracted if a new feature was added.
