### PR TITLE
fix: removed deploy url env

### DIFF
--- a/.github/workflows/cd-devnet-cron.yaml
+++ b/.github/workflows/cd-devnet-cron.yaml
@@ -91,7 +91,6 @@ jobs:
         run: |
           cp -r out/* deploy
           cd deploy
-          echo ${{ secrets.DEPLOY_URL }} > CNAME
           touch .nojekyll
           git add .
           git commit -m $GITHUB_SHA --allow-empty

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -166,7 +166,6 @@ jobs:
         run: |
           cp -r out/* deploy
           cd deploy
-          echo ${{ secrets.DEPLOY_URL }} > CNAME
           touch .nojekyll
           git add .
           git commit -m $GITHUB_SHA --allow-empty
@@ -261,7 +260,6 @@ jobs:
         run: |
           cp -r out/* deploy
           cd deploy
-          echo ${{ secrets.DEPLOY_URL }} > CNAME
           touch .nojekyll
           git add .
           git commit -m $GITHUB_SHA --allow-empty


### PR DESCRIPTION
*This PR removes redundant DEPLOY_URL secret.*

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
