### PR TITLE
feat: filter out super senior tranche when storing deals in store

### DIFF
--- a/src/state/dealSlice.ts
+++ b/src/state/dealSlice.ts
@@ -39,6 +39,9 @@ const getDeals = async (client: CredixClient, market: Market, set: SetState<Deal
 			const dealTranches = tranches[index];
 			if (dealTranches) {
 				deal.tranches = dealTranches;
+
+				// Remove the first tranche as it is the super senior tranche
+				deal.tranches.tranches.shift();
 			}
 
 			return deal;


### PR DESCRIPTION
This PR will:

- filter out the super senior tranche out of the tranches when storing them in the store

## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
