### PR TITLE
feat: add log scale to bullet loan repayment schedule chart

### DIFF
--- a/src/components/BulletLoanRepaymentSchedule.tsx
+++ b/src/components/BulletLoanRepaymentSchedule.tsx
@@ -7,6 +7,7 @@ import { repaymentSchedule } from "@utils/bullet.utils";
 import { Fraction } from "@credix/credix-client";
 import { generateGraphAndTableData } from "@utils/repayment.utils";
 import { RepaymentSchedule } from "./RepaymentSchedule";
+import { ColumnConfig } from "@ant-design/charts";
 
 interface BulletLoanRepaymentScheduleProps {
 	principal: number;
@@ -21,6 +22,12 @@ export const BulletLoanRepaymentSchedule: FunctionComponent<BulletLoanRepaymentS
 }) => {
 	const [graphData, setGraphData] = useState<RepaymentScheduleGraphDataPoint[]>([]);
 	const [dataSource, setDataSource] = useState<RepaymentScheduleTableDataPoint[]>();
+	const graphConfig = {
+		yAxis: {
+			type: "log",
+			base: 10,
+		},
+	} as Partial<ColumnConfig>;
 
 	useEffect(() => {
 		if (principal && financingFee && timeToMaturity) {
@@ -37,5 +44,7 @@ export const BulletLoanRepaymentSchedule: FunctionComponent<BulletLoanRepaymentS
 		}
 	}, [principal, financingFee, timeToMaturity]);
 
-	return <RepaymentSchedule graphData={graphData} dataSource={dataSource} />;
+	return (
+		<RepaymentSchedule graphData={graphData} graphConfig={graphConfig} dataSource={dataSource} />
+	);
 };

--- a/src/components/RepaymentSchedule.tsx
+++ b/src/components/RepaymentSchedule.tsx
@@ -7,14 +7,17 @@ import {
 	RepaymentScheduleTableDataPoint,
 } from "@credix_types/repaymentschedule.types";
 import { useIntl } from "react-intl";
+import { ColumnConfig } from "@ant-design/charts";
 
 interface RepaymentScheduleProps {
 	graphData: RepaymentScheduleGraphDataPoint[];
+	graphConfig?: Partial<ColumnConfig>;
 	dataSource: RepaymentScheduleTableDataPoint[];
 }
 export const RepaymentSchedule: FunctionComponent<RepaymentScheduleProps> = ({
 	graphData,
 	dataSource,
+	graphConfig,
 }) => {
 	const intl = useIntl();
 	const [showTable, setShowTable] = useState(false);
@@ -40,7 +43,7 @@ export const RepaymentSchedule: FunctionComponent<RepaymentScheduleProps> = ({
 					</div>
 				</div>
 				<div className="text-right">
-					<RepaymentScheduleGraph data={graphData} />
+					<RepaymentScheduleGraph data={graphData} config={graphConfig} />
 				</div>
 			</div>
 			{showTable && <RepaymentScheduleTable dataSource={dataSource} />}

--- a/src/components/RepaymentScheduleGraph.tsx
+++ b/src/components/RepaymentScheduleGraph.tsx
@@ -1,15 +1,17 @@
-import { Column } from "@ant-design/plots";
+import { Column, ColumnConfig } from "@ant-design/plots";
 import { RepaymentScheduleGraphDataPoint } from "@credix_types/repaymentschedule.types";
 import { FunctionComponent } from "react";
 import * as Theme from "../../theme.js";
 interface RepaymentScheduleGraphProps {
 	data: RepaymentScheduleGraphDataPoint[];
+	config?: Partial<ColumnConfig>;
 }
 
 export const RepaymentScheduleGraph: FunctionComponent<RepaymentScheduleGraphProps> = ({
 	data,
+	config = {},
 }) => {
-	const config = {
+	const baseConfig = {
 		data,
 		height: 200,
 		width: 320,
@@ -47,7 +49,8 @@ export const RepaymentScheduleGraph: FunctionComponent<RepaymentScheduleGraphPro
 								<div>`;
 			},
 		},
-	};
+		...config,
+	} as ColumnConfig;
 
-	return <Column {...config} />;
+	return <Column {...baseConfig} />;
 };


### PR DESCRIPTION
This PR will:

- display the repayment schedule of a bullet loan with a log scale so the interest repayments are more clear

Before:
<img width="614" alt="afbeelding" src="https://user-images.githubusercontent.com/11614239/176662823-bab3cbd8-1cdf-4e54-aacb-aa1f9907e65d.png">

After:
<img width="606" alt="afbeelding" src="https://user-images.githubusercontent.com/11614239/176662854-766b09f9-82dc-4b07-bad0-1ddf568e825b.png">


## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
