### PR TITLE
fix: projected returns calculation

### DIFF
--- a/src/components/DealInvestments.tsx
+++ b/src/components/DealInvestments.tsx
@@ -25,11 +25,7 @@ export const DealInvestments: FunctionComponent<DealInvestmentsProps> = ({ class
 				// Remove Senior tranche from array
 				.filter((t) => t.index > 1)
 				.map((tranche) => (
-					<TrancheInvestment
-						key={tranche.index}
-						tranche={tranche}
-						repaymentSchedule={deal.repaymentSchedule}
-					/>
+					<TrancheInvestment key={tranche.index} tranche={tranche} deal={deal} />
 				))}
 		</div>
 	);

--- a/src/components/DealTrancheInvest.tsx
+++ b/src/components/DealTrancheInvest.tsx
@@ -1,19 +1,17 @@
 import React, { FunctionComponent } from "react";
 import { classNames } from "@utils/format.utils";
-import { RepaymentSchedule, Tranches } from "@credix/credix-client";
 import { InvestInTranche } from "@components/InvestInTranche";
 import { useIntl } from "react-intl";
+import { DealWithNestedResources } from "@state/dealSlice";
 
 interface DealTrancheInvestProps {
 	className?: string;
-	tranches: Tranches;
-	repaymentSchedule: RepaymentSchedule;
+	deal: DealWithNestedResources;
 }
 
 export const DealTrancheInvest: FunctionComponent<DealTrancheInvestProps> = ({
 	className,
-	tranches,
-	repaymentSchedule,
+	deal,
 }) => {
 	const intl = useIntl();
 	className = classNames([className, "space-y-6"]);
@@ -26,15 +24,11 @@ export const DealTrancheInvest: FunctionComponent<DealTrancheInvestProps> = ({
 					description: "Deal tranche invest: title",
 				})}
 			</div>
-			{tranches?.tranches
+			{deal.tranches?.tranches
 				// Remove Senior tranche from array
 				.filter((t) => t.index > 1)
 				.map((tranche) => (
-					<InvestInTranche
-						key={tranche.index}
-						tranche={tranche}
-						repaymentSchedule={repaymentSchedule}
-					/>
+					<InvestInTranche key={tranche.index} deal={deal} tranche={tranche} />
 				))}
 		</div>
 	);

--- a/src/components/InvestInTranche.tsx
+++ b/src/components/InvestInTranche.tsx
@@ -3,13 +3,7 @@ import { Icon, IconDimension } from "./Icon";
 import { Button } from "./Button";
 import { Input } from "./Input";
 import { Form } from "antd";
-import {
-	Fraction,
-	RepaymentSchedule,
-	Tranche,
-	useCredixClient,
-	TranchePass,
-} from "@credix/credix-client";
+import { Fraction, Tranche, useCredixClient, TranchePass } from "@credix/credix-client";
 import { trancheNames, zeroTokenAmount } from "@consts";
 import { ratioFormatter, toProgramAmount } from "@utils/format.utils";
 import { defineMessages, useIntl } from "react-intl";
@@ -26,16 +20,14 @@ import { config } from "@config";
 import { SolanaCluster } from "@credix_types/solana.types";
 import { investorProjectedReturns } from "@utils/tranche.utils";
 import { validateMaxValue, validateMinValue } from "@utils/validation.utils";
+import { DealWithNestedResources } from "@state/dealSlice";
 
 interface InvestInTrancheProps {
 	tranche: Tranche;
-	repaymentSchedule: RepaymentSchedule;
+	deal: DealWithNestedResources;
 }
 
-export const InvestInTranche: FunctionComponent<InvestInTrancheProps> = ({
-	tranche,
-	repaymentSchedule,
-}) => {
+export const InvestInTranche: FunctionComponent<InvestInTrancheProps> = ({ tranche, deal }) => {
 	const router = useRouter();
 	const { marketplace } = router.query;
 	const intl = useIntl();
@@ -45,7 +37,12 @@ export const InvestInTranche: FunctionComponent<InvestInTrancheProps> = ({
 	const userBaseBalance = useUserBaseBalance();
 	const client = useCredixClient();
 	const fetchMarket = useStore((state) => state.fetchMarket);
-	const projectedReturns = investorProjectedReturns(tranche, repaymentSchedule, userTrancheBalance);
+	const projectedReturns = investorProjectedReturns(
+		tranche,
+		deal.repaymentSchedule,
+		userTrancheBalance,
+		deal.interestFee
+	);
 	const projectedValue = projectedReturns.add(userTrancheBalance?.uiAmount || 0);
 	const maxInvestmentAmount = Math.min(
 		userBaseBalance?.uiAmount,

--- a/src/components/TrancheInvestment.tsx
+++ b/src/components/TrancheInvestment.tsx
@@ -3,7 +3,7 @@ import { Icon, IconDimension } from "./Icon";
 import { Button } from "./Button";
 import { Input } from "./Input";
 import { Form } from "antd";
-import { RepaymentSchedule, Tranche, useCredixClient } from "@credix/credix-client";
+import { Tranche, useCredixClient } from "@credix/credix-client";
 import { trancheNames, zeroTokenAmount } from "@consts";
 import { toProgramAmount } from "@utils/format.utils";
 import { useIntl } from "react-intl";
@@ -22,16 +22,14 @@ import {
 	investorCurrentReturns,
 	investorProjectedReturns,
 } from "@utils/tranche.utils";
+import { DealWithNestedResources } from "@state/dealSlice";
 
 interface TrancheInvestmentProps {
 	tranche: Tranche;
-	repaymentSchedule: RepaymentSchedule;
+	deal: DealWithNestedResources;
 }
 
-export const TrancheInvestment: FunctionComponent<TrancheInvestmentProps> = ({
-	tranche,
-	repaymentSchedule,
-}) => {
+export const TrancheInvestment: FunctionComponent<TrancheInvestmentProps> = ({ tranche, deal }) => {
 	const router = useRouter();
 	const { marketplace } = router.query;
 	const intl = useIntl();
@@ -87,18 +85,19 @@ export const TrancheInvestment: FunctionComponent<TrancheInvestmentProps> = ({
 	}, [tranche, publicKey]);
 
 	useEffect(() => {
-		if (tranche && repaymentSchedule && userTrancheBalance) {
+		if (tranche && deal && userTrancheBalance) {
 			const projectedReturns = investorProjectedReturns(
 				tranche,
-				repaymentSchedule,
-				userTrancheBalance
+				deal.repaymentSchedule,
+				userTrancheBalance,
+				deal.interestFee
 			);
 			setProjectedReturns(projectedReturns);
 
 			const currentReturns = investorCurrentReturns(tranche, userTrancheBalance);
 			setCurrentReturns(currentReturns);
 		}
-	}, [tranche, repaymentSchedule, userTrancheBalance]);
+	}, [tranche, deal, userTrancheBalance]);
 
 	useEffect(() => {
 		if (userTrancheBalance && currentReturns && amountWithdrawn) {

--- a/src/pages/[marketplace]/deals/show.tsx
+++ b/src/pages/[marketplace]/deals/show.tsx
@@ -155,11 +155,7 @@ const Show: NextPageWithLayout = () => {
 				<DealInvestments className="mt-16" deal={deal} />
 			)}
 			{dealStatus === DealStatus.OPEN_FOR_FUNDING && (
-				<DealTrancheInvest
-					className="mt-16"
-					tranches={deal.tranches}
-					repaymentSchedule={deal.repaymentSchedule}
-				/>
+				<DealTrancheInvest className="mt-16" deal={deal} />
 			)}
 		</div>
 	);

--- a/src/utils/tranche.utils.ts
+++ b/src/utils/tranche.utils.ts
@@ -460,13 +460,17 @@ export const calculateInvestorPercentageOfTranche = (
 export const investorProjectedReturns = (
 	tranche: Tranche,
 	repaymentSchedule: RepaymentSchedule,
-	userTrancheBalance: TokenAmount
+	userTrancheBalance: TokenAmount,
+	interestFee: Fraction
 ) => {
 	if (!userTrancheBalance) {
 		return Big(0);
 	}
 
-	const trancheInterest = tranche.returnPercentage.apply(repaymentSchedule.totalInterest.uiAmount);
+	const interestWithoutPerformanceFee = Big(repaymentSchedule.totalInterest.uiAmountString).minus(
+		interestFee.apply(repaymentSchedule.totalInterest.uiAmount)
+	);
+	const trancheInterest = tranche.returnPercentage.apply(interestWithoutPerformanceFee.toNumber());
 	const investorPercentageOfTranche = calculateInvestorPercentageOfTranche(
 		tranche,
 		userTrancheBalance


### PR DESCRIPTION
This PR will:

- fix the projected returns calculation by applying the interest fee on the total interest of the repayment schedule

image below shows the projected returns vs the actual returns the moment the deal has been repaid.
<img width="254" alt="afbeelding" src="https://user-images.githubusercontent.com/11614239/177556099-1b660ade-dc0d-4482-9d27-5c06ab740288.png">


## Checklist

- [x] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
