### PR TITLE
feat: add layout container so pages have a common layout

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -24,7 +24,9 @@ const WithMainMenu = ({ children, showLogo = true }: WithMainMenuProps) => {
 	return (
 		<div className="grid grid-rows-layout">
 			<MainMenu showLogo={showLogo} />
-			{children}
+			<div className="flex justify-center">
+				<div className="max-w-5xl w-full md:py-20 mx-8 pb-8">{children}</div>
+			</div>
 		</div>
 	);
 };

--- a/src/components/Marketplace.tsx
+++ b/src/components/Marketplace.tsx
@@ -73,7 +73,7 @@ const Marketplace: FunctionComponent<MarketplaceProps> = (props) => {
 	return (
 		<main
 			id="index"
-			className="grid grid-cols-1 grid-auto-rows-min gap-y-8 md:grid-cols-12 md:gap-y-12 md:gap-x-14 justify-items-center p-4 pt-8 md:p-8 lg:max-w-6xl lg:justify-self-center"
+			className="grid grid-cols-1 grid-auto-rows-min gap-y-8 md:grid-cols-12 md:gap-y-12 md:gap-x-14 justify-items-center"
 		>
 			<div className="md:text-center md:col-span-12 md:max-w-3xl grid justify-items-center max-w-lg">
 				<h1 className="text-5xl md:text-6xl lg:text-7xl font-semibold font-sans">

--- a/src/components/TrancheInvestment.tsx
+++ b/src/components/TrancheInvestment.tsx
@@ -190,7 +190,7 @@ export const TrancheInvestment: FunctionComponent<TrancheInvestmentProps> = ({ t
 						APR: 15%
 					</div>
 				</TrancheFillLevel>
-				<div className="">
+				<div>
 					<div className="space-y-6">
 						<div>
 							<div className="font-mono font-bold text-base">

--- a/src/components/tables/DealsTable.tsx
+++ b/src/components/tables/DealsTable.tsx
@@ -106,6 +106,7 @@ export const DealsTable = (props: Props) => {
 			icon: "stacked-column-down",
 			dataIndex: "name",
 			key: "name",
+			width: 300,
 			ellipsis: true,
 		},
 		{
@@ -113,7 +114,7 @@ export const DealsTable = (props: Props) => {
 			icon: "coins-alt",
 			dataIndex: "principal",
 			key: "principal",
-			width: 200,
+			width: 250,
 			titleClassName: "justify-end",
 			align: "right",
 			render: (principal: TokenAmount) => (
@@ -124,7 +125,6 @@ export const DealsTable = (props: Props) => {
 			title: intl.formatMessage(MESSAGES.apr),
 			icon: "coins-alt",
 			key: "apr",
-			width: 200,
 			titleClassName: "justify-end",
 			align: "right",
 			dataIndex: "apr",
@@ -135,7 +135,7 @@ export const DealsTable = (props: Props) => {
 			icon: "coins-alt",
 			key: "trancheStructure",
 			dataIndex: "trancheSizePercentages",
-			width: 400,
+			width: 250,
 			titleClassName: "justify-end",
 			align: "right",
 			render: (tranches: number[]) => (

--- a/src/pages/[marketplace]/deals/index.tsx
+++ b/src/pages/[marketplace]/deals/index.tsx
@@ -70,7 +70,7 @@ const DealsPage = () => {
 	}
 
 	return (
-		<div className="space-y-14 py-5 px-4 md:pt-20 md:px-28">
+		<div className="space-y-14">
 			<h2 className="text-5xl md:text-5xl lg:text-5xl font-semibold font-sans">
 				{intl.formatMessage(MESSAGES.title)}
 			</h2>

--- a/src/pages/[marketplace]/deals/new.tsx
+++ b/src/pages/[marketplace]/deals/new.tsx
@@ -253,7 +253,7 @@ const New: NextPageWithLayout = () => {
 	};
 
 	return (
-		<div className="py-5 px-4 md:p-20 md:justify-self-center w-full">
+		<div>
 			<Link to={`/${marketplace}/deals`} label="Go back to all deals" icon="chevron-left-square" />
 			<div className="text-4xl font-sans pt-3 mb-8 capitalize">
 				{intl.formatMessage({

--- a/src/pages/[marketplace]/invest-withdraw.tsx
+++ b/src/pages/[marketplace]/invest-withdraw.tsx
@@ -24,7 +24,7 @@ function InvestWithdraw() {
 	}, [publicKey, client, fetchMarket, marketplace]);
 
 	return (
-		<div className="py-5 px-4 md:pt-12 md:px-20 md:justify-self-center md:w-full md:max-w-7xl lg:max-w-5xl">
+		<div>
 			<div className="md:-ml-[22px] mb-16">
 				<MarketStats market={market} />
 			</div>


### PR DESCRIPTION
This PR will:

- Add a `WithContainer` layout component that can be used to give a page a consistent layout

## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
