### PR TITLE
bump: client to 0.9.1-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	"dependencies": {
 		"@ant-design/charts": "^1.3.6",
 		"@civic/solana-gateway-react": "0.4.13",
-		"@credix/credix-client": "0.9.0-beta.0",
+		"@credix/credix-client": "0.9.1-beta.0",
 		"@credix/prettier-config": "^1.0.0",
 		"@solana/wallet-adapter-base": "^0.9.5",
 		"@solana/wallet-adapter-react": "0.15.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2716,9 +2716,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@credix/credix-client@npm:0.9.0-beta.0":
-  version: 0.9.0-beta.0
-  resolution: "@credix/credix-client@npm:0.9.0-beta.0"
+"@credix/credix-client@npm:0.9.1-beta.0":
+  version: 0.9.1-beta.0
+  resolution: "@credix/credix-client@npm:0.9.1-beta.0"
   dependencies:
     "@identity.com/solana-gateway-ts": ^0.8.2
     "@project-serum/anchor": 0.24.2
@@ -2729,7 +2729,7 @@ __metadata:
     bn.js: ^5.2.0
   peerDependencies:
     react: ^17.0.2
-  checksum: 626593a5d8fcd5607670942769e0dadcc2b09268de9351fe78f784d1d03667423f8fb190f9690e8e56b441ee6818064d8d67eb5d4ee1b86a8a53c13bb1e414ca
+  checksum: 777aa7e7de47c8fa3353418661eda511f2b0c1a307f5c66a093f0ea7c2899ec2d4e5a9906118ee85372c4bbb7d3246439a8a1b43d0822fb51624507d4ea0c9f4
   languageName: node
   linkType: hard
 
@@ -9512,7 +9512,7 @@ __metadata:
     "@civic/solana-gateway-react": 0.4.13
     "@commitlint/cli": ^16.2.4
     "@commitlint/config-conventional": ^16.2.4
-    "@credix/credix-client": 0.9.0-beta.0
+    "@credix/credix-client": 0.9.1-beta.0
     "@credix/eslint-config": ^1.1.0
     "@credix/prettier-config": ^1.0.0
     "@formatjs/cli": ^4.8.4


### PR DESCRIPTION
This PR will

- bump client version to 0.9.1-beta.0

## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
