### PR TITLE
feat: add weighted avg financing fee to marketstats

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	"dependencies": {
 		"@ant-design/charts": "^1.3.6",
 		"@civic/solana-gateway-react": "0.9.0",
-		"@credix/credix-client": "0.9.1-beta.0",
+		"@credix/credix-client": "0.13.2-beta.0",
 		"@credix/prettier-config": "^1.0.0",
 		"@sentry/nextjs": "^6.19.6",
 		"@solana/wallet-adapter-base": "^0.9.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	"dependencies": {
 		"@ant-design/charts": "^1.3.6",
 		"@civic/solana-gateway-react": "0.9.0",
-		"@credix/credix-client": "0.13.2-beta.0",
+		"@credix/credix-client": "0.13.5-beta.0",
 		"@credix/prettier-config": "^1.0.0",
 		"@sentry/nextjs": "^6.19.6",
 		"@solana/wallet-adapter-base": "^0.9.5",

--- a/src/components/MarketStats.tsx
+++ b/src/components/MarketStats.tsx
@@ -1,8 +1,8 @@
-import { Market } from "@credix/credix-client";
-import Big from "big.js";
-import React, { useCallback, useEffect, useState } from "react";
-import { useIntl } from "react-intl";
-import { toUIAmount } from "utils/format.utils";
+import { zeroTokenAmount } from "@consts";
+import { Fraction, Market } from "@credix/credix-client";
+import { TokenAmount } from "@solana/web3.js";
+import React, { useEffect, useState } from "react";
+import { defineMessages, useIntl } from "react-intl";
 import { Statistic } from "./Statistic";
 
 interface MarketStatsProps {
@@ -10,66 +10,77 @@ interface MarketStatsProps {
 }
 
 export const MarketStats = ({ market }: MarketStatsProps) => {
-	const [creditOutstanding, setCreditOutstanding] = useState<number>(0);
-	const [tvl, setTvl] = useState<number>(0);
+	const [creditOutstanding, setCreditOutstanding] = useState<TokenAmount>(zeroTokenAmount);
+	const [tvl, setTvl] = useState<TokenAmount>(zeroTokenAmount);
+	const [weightedAverageFinancingFee, setWeightedAverageFinancingFee] = useState<Fraction>(
+		new Fraction(0, 1)
+	);
 	const intl = useIntl();
 
-	const getTVL = useCallback(async () => {
-		const tvl = await market?.calculateTVL();
-
-		if (tvl) {
-			setTvl(toUIAmount(new Big(tvl)).toNumber() || 0);
-		}
-	}, [market]);
-
-	const getCreditOutstanding = useCallback(async () => {
-		const totalOutstandingCredit = market?.totalOutstandingCredit;
-
-		if (totalOutstandingCredit) {
-			setCreditOutstanding(totalOutstandingCredit.uiAmount);
-		}
-	}, [market]);
-
 	useEffect(() => {
+		const getTVL = async () => {
+			if (market) {
+				const tvl = await market.calculateTVL();
+				setTvl(tvl);
+			}
+		};
 		getTVL();
-	}, [getTVL]);
+	}, [market]);
 
 	useEffect(() => {
+		const getCreditOutstanding = async () => {
+			if (market) {
+				const totalOutstandingCredit = await market.totalOutstandingCredit();
+				setCreditOutstanding(totalOutstandingCredit);
+			}
+		};
 		getCreditOutstanding();
-	}, [getCreditOutstanding]);
+	}, [market]);
 
+	useEffect(() => {
+		const getWeightedAverageFinancingFee = async () => {
+			if (market) {
+				const weightedAverageFinancingFee = await market.calculateWeightedAverageFinancingFee();
+				setWeightedAverageFinancingFee(weightedAverageFinancingFee);
+			}
+		};
+
+		getWeightedAverageFinancingFee();
+	}, [market]);
 	return (
 		<div className="grid grid-cols-1 gap-y-8 md:grid-cols-3 md:gap-x-14 md:gap-y-12">
 			<div className="w-full flex justify-center">
-				<Statistic
-					label={intl.formatMessage({
-						defaultMessage: "TVL",
-						description: "MarketStats: total value locked",
-					})}
-					currency="USDC"
-					value={tvl}
-				/>
+				<Statistic label={intl.formatMessage(MESSAGES.tvl)} currency="USDC" value={tvl.uiAmount} />
 			</div>
 			<div className="w-full flex justify-center">
 				<Statistic
-					label={intl.formatMessage({
-						defaultMessage: "Average financing fee",
-						description: "MarketStats: average financing fee",
-					})}
+					label={intl.formatMessage(MESSAGES.averageFinancingFee)}
 					isPercentage={true}
-					value={0.12}
+					value={weightedAverageFinancingFee.toNumber()}
 				/>
 			</div>
 			<div className="w-full flex justify-center">
 				<Statistic
-					label={intl.formatMessage({
-						defaultMessage: "Credit outstanding",
-						description: "MarketStats: credit outstanding",
-					})}
+					label={intl.formatMessage(MESSAGES.creditOutstanding)}
 					currency="USDC"
-					value={creditOutstanding}
+					value={creditOutstanding.uiAmount}
 				/>
 			</div>
 		</div>
 	);
 };
+
+const MESSAGES = defineMessages({
+	creditOutstanding: {
+		defaultMessage: "Credit outstanding",
+		description: "MarketStats: credit outstanding",
+	},
+	averageFinancingFee: {
+		defaultMessage: "Average financing fee",
+		description: "MarketStats: average financing fee",
+	},
+	tvl: {
+		defaultMessage: "TVL",
+		description: "MarketStats: total value locked",
+	},
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2727,9 +2727,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@credix/credix-client@npm:0.9.1-beta.0":
-  version: 0.9.1-beta.0
-  resolution: "@credix/credix-client@npm:0.9.1-beta.0"
+"@credix/credix-client@npm:0.13.2-beta.0":
+  version: 0.13.2-beta.0
+  resolution: "@credix/credix-client@npm:0.13.2-beta.0"
   dependencies:
     "@identity.com/solana-gateway-ts": ^0.8.2
     "@project-serum/anchor": 0.24.2
@@ -2738,9 +2738,10 @@ __metadata:
     "@solana/web3.js": ^1.43.4
     big.js: ^6.1.1
     bn.js: ^5.2.0
+    node-irr: ^2.0.3
   peerDependencies:
     react: ^17.0.2
-  checksum: 777aa7e7de47c8fa3353418661eda511f2b0c1a307f5c66a093f0ea7c2899ec2d4e5a9906118ee85372c4bbb7d3246439a8a1b43d0822fb51624507d4ea0c9f4
+  checksum: f9b290550e866254d502faf41278e7630b426fc7b3aa1418827d1beb65375f24cf263a97789b29196e14d04732e7c0f99e2d8601def56355bbe62c5d4fe03caa
   languageName: node
   linkType: hard
 
@@ -9736,7 +9737,7 @@ __metadata:
     "@civic/solana-gateway-react": 0.9.0
     "@commitlint/cli": ^16.2.4
     "@commitlint/config-conventional": ^16.2.4
-    "@credix/credix-client": 0.9.1-beta.0
+    "@credix/credix-client": 0.13.2-beta.0
     "@credix/eslint-config": ^1.1.0
     "@credix/prettier-config": ^1.0.0
     "@formatjs/cli": ^4.8.4
@@ -16492,6 +16493,13 @@ __metadata:
   version: 0.4.0
   resolution: "node-int64@npm:0.4.0"
   checksum: d0b30b1ee6d961851c60d5eaa745d30b5c95d94bc0e74b81e5292f7c42a49e3af87f1eb9e89f59456f80645d679202537de751b7d72e9e40ceea40c5e449057e
+  languageName: node
+  linkType: hard
+
+"node-irr@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "node-irr@npm:2.0.3"
+  checksum: 590aa41aa24f3f778516188793f7d90ddb59e41de62be2412c9b6e04f780577c40dd4029a5cf48c59eb220212a4ee685bc47bd6fc7dbb06363fbd0333edd022b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2727,9 +2727,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@credix/credix-client@npm:0.13.2-beta.0":
-  version: 0.13.2-beta.0
-  resolution: "@credix/credix-client@npm:0.13.2-beta.0"
+"@credix/credix-client@npm:0.13.5-beta.0":
+  version: 0.13.5-beta.0
+  resolution: "@credix/credix-client@npm:0.13.5-beta.0"
   dependencies:
     "@identity.com/solana-gateway-ts": ^0.8.2
     "@project-serum/anchor": 0.24.2
@@ -2738,10 +2738,11 @@ __metadata:
     "@solana/web3.js": ^1.43.4
     big.js: ^6.1.1
     bn.js: ^5.2.0
+    buffer-layout: ^1.2.2
     node-irr: ^2.0.3
   peerDependencies:
     react: ^17.0.2
-  checksum: f9b290550e866254d502faf41278e7630b426fc7b3aa1418827d1beb65375f24cf263a97789b29196e14d04732e7c0f99e2d8601def56355bbe62c5d4fe03caa
+  checksum: 525b26148abcfe4bf282a7ede9cdbaa90196897c7b3fec2e03b3530a603675d8c4f1f71ce9a4469b6e40b64dd928a609a442991f60c0e007a86d2a60789b613f
   languageName: node
   linkType: hard
 
@@ -9737,7 +9738,7 @@ __metadata:
     "@civic/solana-gateway-react": 0.9.0
     "@commitlint/cli": ^16.2.4
     "@commitlint/config-conventional": ^16.2.4
-    "@credix/credix-client": 0.13.2-beta.0
+    "@credix/credix-client": 0.13.5-beta.0
     "@credix/eslint-config": ^1.1.0
     "@credix/prettier-config": ^1.0.0
     "@formatjs/cli": ^4.8.4


### PR DESCRIPTION
This PR will:

- add weighted avg financing fee to marketstats
- fix creditOutstanding and tvl data types so they work with the newest version of the client

## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
