### PR TITLE
fix: amortization schedule being off when financing fee was a fractional number

### DIFF
--- a/__tests__/utils/repayment.test.ts
+++ b/__tests__/utils/repayment.test.ts
@@ -148,6 +148,18 @@ describe("amortization", () => {
 
 		expect(principalSum.eq(principal)).toBeTruthy();
 	});
+
+	test.only("the sum of all the principal in the schedule adds up to the starting principal with a fractional rate", () => {
+		const periods = 12;
+		const principal = defaultPrincipal;
+		const financingFee = new Fraction(125, 1000);
+		const repaymentPeriod = periods * DAYS_IN_REPAYMENT_PERIOD;
+		const schedule = Amortization.repaymentSchedule(principal, financingFee, repaymentPeriod);
+
+		const principalSum = Big(schedule.reduce((acc, curr) => acc + curr.principal, 0));
+
+		expect(principalSum.eq(principal)).toBeTruthy();
+	});
 });
 
 describe("bullet", () => {

--- a/src/utils/amortization.utils.ts
+++ b/src/utils/amortization.utils.ts
@@ -89,7 +89,7 @@ export const repaymentSchedule = (
 		} else {
 			schedule[paymentPeriods - 1].principal += round(
 				Big(cumulativePrincipalRest),
-				Big.roundDown
+				Big.roundHalfEven
 			).toNumber();
 		}
 


### PR DESCRIPTION
This pr will:

- change the rounding when creating the principals of an amortization repayment schedule so they correctly handle fractional financing fees

*List which issues are fixed by this PR. You must list at least one issue.*

## Checklist

- [ ] I used the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [ ] Unit tests have been created if a new feature was added.
- [ ] Translations have been added and extracted if a new feature was added.
